### PR TITLE
implemented highlight-based macros

### DIFF
--- a/src/bookinfo.mbx
+++ b/src/bookinfo.mbx
@@ -57,36 +57,36 @@
 \newcommand{\substitute}[1]{\highlight{#1}}
 %
 %
-%  add (add to the right)
-%  Usage: x-1\add{1}\amp=1\add{1}
-\newcommand{\add}[1]{\highlight{{}+#1}}
+%  addright (add to the right)
+%  Usage: x-1\addright{1}\amp=1\addright{1}
+\newcommand{\addright}[1]{\highlight{{}+#1}}
 %
 %
-%  addto (add to the left)
-%  Usage: \addto{1}x-1\amp=\addto{1}1
-\newcommand{\addto}[1]{\highlight{#1+{}}}
+%  addleft (add to the left)
+%  Usage: \addleft{1}x-1\amp=\addleft{1}1
+\newcommand{\addleft}[1]{\highlight{#1+{}}}
 %
 %
-%  subtract (subtract to the right)
-%  Usage: x+1\subtract{1}\amp=1\subtract{1}
-\newcommand{\subtract}[1]{\highlight{{}-#1}}
+%  subtractright (subtract to the right)
+%  Usage: x+1\subtractright{1}\amp=1\subtractright{1}
+\newcommand{\subtractright}[1]{\highlight{{}-#1}}
 %
 %
-%  multiply (multiply to the right)
-%  Usage: \frac{x}{2}\multiply{2}\amp=1\multiply{2}
-%  Usage: \frac{x}{2}\multiply[\times]{2}\amp=1\multiply[\times]{2}
-%  Usage: \frac{x}{2}\multiply[]{2}\amp=1\multiply[]{2}
-\newcommand{\multiply}[2][\cdot]{\highlight{{}#1#2}}
+%  multiplyright (multiply to the right)
+%  Usage: \frac{x}{2}\multiplyright{2}\amp=1\multiplyright{2}
+%  Usage: \frac{x}{2}\multiplyright[\times]{2}\amp=1\multiplyright[\times]{2}
+%  Usage: \frac{x}{2}\multiplyright[]{2}\amp=1\multiplyright[]{2}
+\newcommand{\multiplyright}[2][\cdot]{\highlight{{}#1#2}}
 %
 %
-%  multiplyby (multiply to the left)
-%  Usage: \multiplyby{2}\frac{x}{2}\amp=\multiplyby{2}1
-\newcommand{\multiplyby}[1]{\highlight{#1\cdot{}}}
+%  multiplyleft (multiply to the left)
+%  Usage: \multiplyleft{2}\frac{x}{2}\amp=\multiplyleft{2}1
+\newcommand{\multiplyleft}[1]{\highlight{#1\cdot{}}}
 %
 %
-%  divide (divide with a fraction bar)
-%  Usage: \divide{2y}{2}\amp=\divide{x+2}{2}
-\newcommand{\divide}[2]{\frac{#1}{\highlight{#2}}}
+%  divideunder (divide with a fraction bar)
+%  Usage: \divideunder{2y}{2}\amp=\divideunder{x+2}{2}
+\newcommand{\divideunder}[2]{\frac{#1}{\highlight{#2}}}
 %
 %
 

--- a/src/section-addition-and-subtraction-of-rational-expressions.mbx
+++ b/src/section-addition-and-subtraction-of-rational-expressions.mbx
@@ -55,7 +55,7 @@
         </example>
 
         <p>Let's review how to add fractions with different denominators:<md>
-            <mrow>\frac{1}{6}+\frac{1}{8}\amp=\frac{1\highlight{\cdot4}}{6\highlight{\cdot4}}+\frac{1\highlight{\cdot3}}{8\highlight{\cdot3}}</mrow>
+            <mrow>\frac{1}{6}+\frac{1}{8}\amp=\frac{1\multiplyright{4}}{6\multiplyright{4}}+\frac{1\multiplyright{3}}{8\multiplyright{3}}</mrow>
             <mrow>\amp=\frac{4}{24}+\frac{3}{24}</mrow>
             <mrow>\amp=\frac{4+3}{24}</mrow>
             <mrow>\amp=\frac{7}{24}</mrow>
@@ -86,7 +86,7 @@
             </statement>
             <solution>
                 <p>The common denominator of <m>x^2y</m> and <m>xy^2</m> must include two <m>x</m>'s and two <m>y</m>'s, so it is <m>x^2y^2</m>. We will change both denominators to <m>x^2y^2</m> before doing addition.<md>
-                    <mrow>\frac{2}{x^2y}+\frac{3}{xy^2}\amp=\frac{2\highlight{\cdot y}}{x^2y\highlight{\cdot y}}+\frac{3\highlight{\cdot x}}{xy^2\highlight{\cdot x}}</mrow>
+                    <mrow>\frac{2}{x^2y}+\frac{3}{xy^2}\amp=\frac{2\multiplyright{y}}{x^2y\multiplyright{y}}+\frac{3\multiplyright{x}}{xy^2\multiplyright{x}}</mrow>
                     <mrow>\amp=\frac{2y}{x^2y^2}+\frac{3x}{x^2y^2}</mrow>
                     <mrow>\amp=\frac{2y+3x}{x^2y^2}</mrow>
                 </md></p>
@@ -98,10 +98,10 @@
                 <p>Subtract rational expressions <m>\frac{2}{x^2+x}-\frac{1}{x^2}</m></p>
             </statement>
             <solution>
-                <p>We must avoid this mistake:<me>\frac{2}{x^2+x}-\frac{1}{x^2}=\frac{2}{x^2+x}-\frac{1\highlight{+x}}{x^2\highlight{+x}}</me>We can only multiply or divide the same number in a fraction's numerator and denominator; we may not add or subtract numbers in the mistake above. The correct first step is to factor the denominators:<md>
+                <p>We must avoid this mistake:<me>\frac{2}{x^2+x}-\frac{1}{x^2}=\frac{2}{x^2+x}-\frac{1\addright{x}}{x^2\addright{x}}</me>We can only multiply or divide the same number in a fraction's numerator and denominator; we may not add or subtract numbers in the mistake above. The correct first step is to factor the denominators:<md>
                     <mrow>\frac{2}{x^2+x}-\frac{1}{x^2}\amp=\frac{2}{x(x+1)}-\frac{1}{x^2}</mrow>
                 </md>The common denominator of <m>x(x+1)</m> and <m>x^2</m> must include two <m>x</m>'s and one <m>(x+1)</m> as factors, and it is <m>x^2(x+1)</m>. The rest of the solution is:<md>
-                    <mrow>\amp=\frac{2\highlight{\cdot x}}{x(x+1)\highlight{\cdot x}}-\frac{1\highlight{\cdot(x+1)}}{x^2\highlight{\cdot(x+1)}}</mrow>
+                    <mrow>\amp=\frac{2\multiplyright{x}}{x(x+1)\multiplyright{x}}-\frac{1\multiplyright{(x+1)}}{x^2\multiplyright{(x+1)}}</mrow>
                     <mrow>\amp=\frac{2x}{x^2(x+1)}-\frac{x+1}{x^2(x+1)}</mrow>
                     <mrow>\amp=\frac{2x-(x+1)}{x^2(x+1)}</mrow>
                     <mrow>\amp=\frac{2x-x-1}{x^2(x+1)}</mrow>
@@ -123,7 +123,7 @@
             <solution>
                 <p><md>
                     <mrow>\frac{y}{y-2}-\frac{8y-8}{y^2-4}\amp=\frac{y}{y-2}-\frac{8y-8}{(y+2)(y-2)}</mrow>
-                    <mrow>\amp=\frac{y\highlight{\cdot(y+2)}}{(y-2)\highlight{\cdot(y+2)}}-\frac{8y-8}{(y+2)(y-2)}</mrow>
+                    <mrow>\amp=\frac{y\multiplyright{(y+2)}}{(y-2)\multiplyright{(y+2)}}-\frac{8y-8}{(y+2)(y-2)}</mrow>
                     <mrow>\amp=\frac{y^2+2y}{(y+2)(y-2)}-\frac{8y-8}{(y+2)(y-2)}</mrow>
                     <mrow>\amp=\frac{y^2+2y-(8y-8)}{(y+2)(y-2)}</mrow>
                     <mrow>\amp=\frac{y^2+2y-8y+8}{(y+2)(y-2)}</mrow>
@@ -143,7 +143,7 @@
             <solution>
                 <p><md>
                     <mrow>-\frac{2}{r-1}+r\amp=-\frac{2}{r-1}+\frac{r}{1}</mrow>
-                    <mrow>\amp=-\frac{2}{r-1}+\frac{r\highlight{\cdot(r-1)}}{1\highlight{\cdot(r-1)}}</mrow>
+                    <mrow>\amp=-\frac{2}{r-1}+\frac{r\multiplyright{(r-1)}}{1\multiplyright{(r-1)}}</mrow>
                     <mrow>\amp=\frac{-2}{r-1}+\frac{r^2-r}{r-1}</mrow>
                     <mrow>\amp=\frac{-2+r^2-r}{r-1}</mrow>
                     <mrow>\amp=\frac{r^2-r-2}{r-1}</mrow>

--- a/src/section-completing-the-square-and-vertex-form.mbx
+++ b/src/section-completing-the-square-and-vertex-form.mbx
@@ -57,7 +57,7 @@
 
         <p>Let's go back to solving <m>x^2+10x=-21</m>. By <m>x^2+10x+25=(x+5)^2</m>, we will add <m>25</m> on both sides of the equation, and we have:<md>
             <mrow>x^2+10x\amp=-21</mrow>
-            <mrow>x^2+10x\highlight{+25}\amp=-21\highlight{+25}</mrow>
+            <mrow>x^2+10x\addright{25}\amp=-21\addright{25}</mrow>
             <mrow>(x+5)^2\amp=4</mrow>
             <mrow>\sqrt{(x+5)^2}\amp=\pm\sqrt{4}</mrow>
             <mrow>x+5\amp=\pm2</mrow>
@@ -80,7 +80,7 @@
                 <p>Step Two: By <m>x^2-2ax+a^2=(x-a)^2</m>, we have <m>y^2-20y+100=(y-10)^2</m>.</p>
                 <p>To solve the equation, we need to add <m>100</m> on both sides of the equation:<md>
                     <mrow>y^2-20y\amp=21</mrow>
-                    <mrow>y^2-20y\highlight{+100}\amp=21\highlight{+100}</mrow>
+                    <mrow>y^2-20y\addright{100}\amp=21\addright{100}</mrow>
                     <mrow>(y-10)^2\amp=121</mrow>
                     <mrow>\sqrt{(y-10)^2}\amp=\pm\sqrt{121}</mrow>
                     <mrow>y-10\amp=\pm11</mrow>
@@ -105,7 +105,7 @@
                 <p>Step Two: By <m>x^2-2ax+a^2=(x-a)^2</m>, we have <m>z^2-3z+\frac{9}{4}=(z-\frac{3}{2})^2</m>.</p>
                 <p>To solve the equation, we need to add <m>\frac{9}{4}</m> on both sides of the equation:<md>
                     <mrow>z^2-3z\amp=10</mrow>
-                    <mrow>z^2-3z\highlight{+\frac{9}{4}}\amp=10\highlight{+\frac{9}{4}}</mrow>
+                    <mrow>z^2-3z\addright{\frac{9}{4}}\amp=10\addright{\frac{9}{4}}</mrow>
                     <mrow>(z-\frac{3}{2})^2\amp=\frac{40}{4}+\frac{9}{4}</mrow>
                     <mrow>(z-\frac{3}{2})^2\amp=\frac{49}{4}</mrow>
                     <mrow>\sqrt{(z-\frac{3}{2})^2}\amp=\pm\sqrt{\frac{49}{4}}</mrow>
@@ -126,7 +126,7 @@
             <solution>
                 <p>Because there is a leading coefficient, we will remove it by multiplying both sides of the equation by <m>\frac{1}{2}</m>:<md>
                     <mrow>2r^2+2r\amp=1</mrow>
-                    <mrow>\highlight{\frac{1}{2}\cdot}(2r^2+2r)\amp=\highlight{\frac{1}{2}\cdot}1</mrow>
+                    <mrow>\multiplyleft{\frac{1}{2}}(2r^2+2r)\amp=\multiplyleft{\frac{1}{2}}1</mrow>
                     <mrow>\frac{1}{2}\cdot2r^2+\frac{1}{2}\cdot2r\amp=\frac{1}{2}</mrow>
                     <mrow>r^2+r\amp=\frac{1}{2}</mrow>
                 </md>Next, we will complete the square.</p>
@@ -134,7 +134,7 @@
                 <p>Step Two: By <m>x^2+2ax+a^2=(x+a)^2</m>, we have <m>r^2+r+\frac{1}{4}=(r+\frac{1}{2})^2</m>.</p>
                 <p>To solve the equation, we need to add <m>\frac{1}{4}</m> on both sides of the equation:<md>
                     <mrow>r^2+r\amp=\frac{1}{2}</mrow>
-                    <mrow>r^2+r\highlight{+\frac{1}{4}}\amp=\frac{1}{2}\highlight{+\frac{1}{4}}</mrow>
+                    <mrow>r^2+r\addright{\frac{1}{4}}\amp=\frac{1}{2}\addright{\frac{1}{4}}</mrow>
                     <mrow>(r+\frac{1}{2})^2\amp=\frac{2}{4}+\frac{1}{4}</mrow>
                     <mrow>(r+\frac{1}{2})^2\amp=\frac{3}{4}</mrow>
                     <mrow>\sqrt{(r+\frac{1}{2})^2}\amp=\pm\sqrt{\frac{3}{4}}</mrow>
@@ -220,7 +220,7 @@
 
         <p>There is a leading coefficient, <m>-10</m>. When we solve the equation in <xref ref="example-solving-quadratic-equation-by-completing-the-square-with-leading-coefficient">Example</xref>, we removed the leading coefficient. Let's try to use the same skill:<md>
             <mrow>f(x)\amp=-10x^2+150x+1000</mrow>
-            <mrow>\highlight{-\frac{1}{10}\cdot}f(x)\amp=\highlight{-\frac{1}{10}\cdot}(-10x^2+150x+1000)</mrow>
+            <mrow>\multiplyleft{-\frac{1}{10}}f(x)\amp=\multiplyleft{-\frac{1}{10}}(-10x^2+150x+1000)</mrow>
             <mrow>-\frac{1}{10}f(x)\amp=x^2-15x-100</mrow>
         </md>When we write the function <m>f(x)</m>, we cannot write the left side as <m>-\frac{1}{10}f(x)</m>. This skill doesn't help us here, but it worked for the equation in <xref ref="example-solving-quadratic-equation-by-completing-the-square-with-leading-coefficient">Example</xref> because the other side of the equation is <m>0</m>.</p>
 
@@ -253,9 +253,9 @@
 
         <p>You might wonder why <m>(7.5,1562.5)</m> must be the parabola's vertex, instead of a different point on the parabola. This can be explained by the function's range. We know the square of a number must be positive or zero, so we have:<md>
             <mrow>(x-7.5)^2\amp\ge0</mrow>
-            <mrow>\highlight{-10\cdot}(x-7.5)^2\amp\le\highlight{-10\cdot}0</mrow>
+            <mrow>\multiplyleft{-10}(x-7.5)^2\amp\le\multiplyleft{-10}0</mrow>
             <mrow>-10(x-7.5)^2\amp\le0</mrow>
-            <mrow>-10(x-7.5)^2\highlight{+1562.5}\amp\le0\highlight{+1562.5}</mrow>
+            <mrow>-10(x-7.5)^2\addright{1562.5}\amp\le0\addright{1562.5}</mrow>
             <mrow>-10(x-7.5)^2+1562.5\amp\le1562.5</mrow>
             <mrow>f(x)\amp\le1562.5</mrow>
         </md>The result implies the maximum value of <m>f(x)</m> is <m>1562.5</m>, making <m>(7.5,1562.5)</m> the parabola's vertex.</p>

--- a/src/section-complex-fractions.mbx
+++ b/src/section-complex-fractions.mbx
@@ -38,15 +38,15 @@
         </md></p>
 
         <p>We will learn an easier method. In a fraction, we multiply the numerator and denominator by the same number, and the fraction's value doesn't change. For example:<md>
-            <mrow>\frac{1}{2}\amp=\frac{1\highlight{\cdot2}}{2\highlight{\cdot2}}=\frac{2}{4}</mrow>
-            <mrow>\frac{1}{2}\amp=\frac{1\highlight{\cdot3}}{2\highlight{\cdot3}}=\frac{3}{6}</mrow>
+            <mrow>\frac{1}{2}\amp=\frac{1\multiplyright{2}}{2\multiplyright{2}}=\frac{2}{4}</mrow>
+            <mrow>\frac{1}{2}\amp=\frac{1\multiplyright{3}}{2\multiplyright{3}}=\frac{3}{6}</mrow>
         </md>Note that <m>\frac{1}{2}\cdot2=1</m>. For <m>\frac{\frac{1}{2}}{3}</m>, to remove the fraction <m>\frac{1}{2}</m>, we multiply the numerator and denominator by <m>2</m>, and we have:<md>
-            <mrow>\frac{\frac{1}{2}}{3}\amp=\frac{\frac{1}{2}\highlight{\cdot2}}{3\highlight{\cdot2}}</mrow>
+            <mrow>\frac{\frac{1}{2}}{3}\amp=\frac{\frac{1}{2}\multiplyright{2}}{3\multiplyright{2}}</mrow>
             <mrow>\amp=\frac{1}{6}</mrow>
         </md></p>
 
         <p>Compare the problem above with the following one:<md>
-            <mrow>\frac{1}{\frac{2}{3}}\amp=\frac{{1}\highlight{\cdot3}}{\frac{2}{3}\highlight{\cdot3}}</mrow>
+            <mrow>\frac{1}{\frac{2}{3}}\amp=\frac{{1}\multiplyright{3}}{\frac{2}{3}\multiplyright{3}}</mrow>
             <mrow>\amp=\frac{3}{2}</mrow>
         </md>So <m>\frac{\frac{1}{2}}{3}</m> and <m>\frac{1}{\frac{2}{3}}</m> have different values.</p>
 
@@ -58,7 +58,7 @@
             </statement>
             <solution>
                 <p>We multiply the numerator and denominator by the common denominator of <m>2</m> and <m>3</m>, which is <m>6</m>:<md>
-                    <mrow>\frac{\frac{1}{2}}{\frac{1}{3}}\amp=\frac{\frac{1}{2}\highlight{\cdot6}}{\frac{1}{3}\highlight{\cdot6}}</mrow>
+                    <mrow>\frac{\frac{1}{2}}{\frac{1}{3}}\amp=\frac{\frac{1}{2}\multiplyright{6}}{\frac{1}{3}\multiplyright{6}}</mrow>
                     <mrow>\amp=\frac{3}{2}</mrow>
                 </md>Since the fraction line serves the same function as the division sign, we have the following shortcut when we multiply fractions:<md>
                     <mrow>\frac{1}{2}\cdot{6}\amp=6\div2\cdot1=3</mrow>
@@ -73,7 +73,7 @@
             </statement>
             <solution>
                 <p>We need to remove <m>\frac{1}{2}</m> and <m>\frac{1}{3}</m>, so we multiply the numerator and denominator by the common denominator of <m>2</m> and <m>3</m>, which is <m>6</m>. Note that we don't consider <m>5</m> when we calculate the common denominator, because <m>5</m> is not a fraction. The solution is:<md>
-                    <mrow>\frac{\frac{1}{2}+\frac{1}{3}}{5}\amp=\frac{\highlight{6\cdot}(\frac{1}{2}+\frac{1}{3})}{\highlight{6\cdot}5}</mrow>
+                    <mrow>\frac{\frac{1}{2}+\frac{1}{3}}{5}\amp=\frac{\multiplyleft{6}(\frac{1}{2}+\frac{1}{3})}{\multiplyleft{6}5}</mrow>
                     <mrow>\amp=\frac{6\cdot\frac{1}{2}+6\cdot\frac{1}{3}}{30}</mrow>
                     <mrow>\amp=\frac{3+2}{30}</mrow>
                     <mrow>\amp=\frac{5}{30}</mrow>
@@ -90,7 +90,7 @@
             </statement>
             <solution>
                 <p>We multiply the numerator and denominator by the common denominator of <m>x</m> and <m>y</m>, which is <m>xy</m>:<md>
-                    <mrow>\frac{\frac{1}{x}+\frac{1}{y}}{\frac{1}{x}-\frac{1}{y}}\amp=\frac{\highlight{xy\cdot}(\frac{1}{x}+\frac{1}{y})}{\highlight{xy\cdot}(\frac{1}{x}-\frac{1}{y})}</mrow>
+                    <mrow>\frac{\frac{1}{x}+\frac{1}{y}}{\frac{1}{x}-\frac{1}{y}}\amp=\frac{\multiplyleft{xy}(\frac{1}{x}+\frac{1}{y})}{\multiplyleft{xy}(\frac{1}{x}-\frac{1}{y})}</mrow>
                     <mrow>\amp=\frac{xy\cdot\frac{1}{x}+xy\cdot\frac{1}{y}}{xy\cdot\frac{1}{x}-xy\cdot\frac{1}{y}}</mrow>
                     <mrow>\amp=\frac{y+x}{y-x}</mrow>
                 </md></p>
@@ -104,7 +104,7 @@
             <solution>
                 <p>First, we factor all denominators if possible:<me>\frac{\frac{1}{x+3}+\frac{1}{x-3}}{\frac{1}{x^2-9}-1}=\frac{\frac{1}{x+3}+\frac{1}{x-3}}{\frac{1}{(x+3)(x-3)}-1}</me>Next, identify the common denominator of those three fractions, which is <m>(x+3)(x-3)</m>. We multiply the numerator and denominator by the common denominator:<md>
                     <mrow>\frac{\frac{1}{x+3}+\frac{1}{x-3}}{\frac{1}{x^2-9}-1}\amp=\frac{\frac{1}{x+3}+\frac{1}{x-3}}{\frac{1}{(x+3)(x-3)}-1}</mrow>
-                    <mrow>\amp=\frac{\highlight{(x+3)(x-3)\cdot}[\frac{1}{x+3}+\frac{1}{x-3}]}{\highlight{(x+3)(x-3)\cdot}[\frac{1}{(x+3)(x-3)}-1]}</mrow>
+                    <mrow>\amp=\frac{\multiplyleft{(x+3)(x-3)}[\frac{1}{x+3}+\frac{1}{x-3}]}{\multiplyleft{(x+3)(x-3)}[\frac{1}{(x+3)(x-3)}-1]}</mrow>
                     <mrow>\amp=\frac{(x+3)(x-3)\cdot\frac{1}{x+3}+(x+3)(x-3)\cdot\frac{1}{x-3}}{(x+3)(x-3)\cdot\frac{1}{(x+3)(x-3)}-(x+3)(x-3)\cdot1}</mrow>
                     <mrow>\amp=\frac{(x-3)+(x+3)}{1-(x+3)(x-3)}</mrow>
                     <mrow>\amp=\frac{x-3+x+3}{1-(x^2-9)}</mrow>

--- a/src/section-complex-number-operations.mbx
+++ b/src/section-complex-number-operations.mbx
@@ -293,13 +293,13 @@
 
         <sidebyside>
             <p><md>
-                <mrow>\frac{2}{\sqrt{2}}\amp=\frac{2\highlight{\cdot\sqrt{2}}}{\sqrt{2}\highlight{\cdot\sqrt{2}}}</mrow>
+                <mrow>\frac{2}{\sqrt{2}}\amp=\frac{2\multiplyright{\sqrt{2}}}{\sqrt{2}\multiplyright{\sqrt{2}}}</mrow>
                 <mrow>\amp=\frac{2\sqrt{2}}{2}</mrow>
                 <mrow>\amp=\sqrt{2}</mrow>
             </md></p>
 
             <p><md>
-                <mrow>\frac{2}{i}\amp=\frac{2\highlight{\cdot i}}{i\highlight{\cdot i}}</mrow>
+                <mrow>\frac{2}{i}\amp=\frac{2\multiplyright{i}}{i\multiplyright{i}}</mrow>
                 <mrow>\amp=\frac{2i}{-1}</mrow>
                 <mrow>\amp=-2i</mrow>
             </md></p>
@@ -314,7 +314,7 @@
                 <mrow>\amp=16-18</mrow>
                 <mrow>\amp=-2</mrow>
             </md>The solution is:<md>
-                <mrow>\frac{1}{4+3\sqrt{2}}\amp=\frac{1\highlight{\cdot(4-3\sqrt{2})}}{(4+3\sqrt{2})\highlight{\cdot(4-3\sqrt{2})}}</mrow>
+                <mrow>\frac{1}{4+3\sqrt{2}}\amp=\frac{1\multiplyright{(4-3\sqrt{2})}}{(4+3\sqrt{2})\multiplyright{(4-3\sqrt{2})}}</mrow>
                 <mrow>\amp=\frac{4-3\sqrt{2}}{-2}</mrow>
                 <mrow>\amp=-\frac{4-3\sqrt{2}}{2}</mrow>
             </md></p>
@@ -326,7 +326,7 @@
                 <mrow>\amp=16+9</mrow>
                 <mrow>\amp=25</mrow>
             </md>The solution is:<md>
-                <mrow>\frac{1}{4+3i}\amp=\frac{1\highlight{\cdot(4-3i)}}{(4+3i)\highlight{\cdot(4-3i)}}</mrow>
+                <mrow>\frac{1}{4+3i}\amp=\frac{1\multiplyright{(4-3i)}}{(4+3i)\multiplyright{(4-3i)}}</mrow>
                 <mrow>\amp=\frac{4-3i}{25}</mrow>
                 <mrow>\amp=\frac{4}{25}-\frac{3}{25}i</mrow>
             </md>Note that we always write a complex number in the format of <m>a+bi</m>.</p>
@@ -340,7 +340,7 @@
             </statement>
             <solution>
                 <p>To remove <m>i</m> in denominator, we multiply the numerator and denominator by <m>2+4i</m>:<md>
-                    <mrow>\frac{1+2i}{2-4i}\amp=\frac{(1+2i)\highlight{(2+4i)}}{(2-4i)\highlight{(2+4i)}}</mrow>
+                    <mrow>\frac{1+2i}{2-4i}\amp=\frac{(1+2i)\multiplyright[]{(2+4i)}}{(2-4i)\multiplyright[]{(2+4i)}}</mrow>
                     <mrow>\amp=\frac{1(2+4i)+2i(2+4i)}{(2)^2-(4i)^2}</mrow>
                     <mrow>\amp=\frac{2+4i+4i+8i^2}{4-16i^2}</mrow>
                     <mrow>\amp=\frac{2+8i+8(-1)}{4-16(-1)}</mrow>

--- a/src/section-complex-root-of-quadratic-functions.mbx
+++ b/src/section-complex-root-of-quadratic-functions.mbx
@@ -35,10 +35,10 @@
         <p>To check whether the plane will hit the ground during the stunt, we substitute <m>h(t)</m> in the function with <m>0</m> and solve the quadratic equation<me>0=0.5t^2-5t+12</me>We will solve this equation by completing the square.<md>
             <mrow>g(t)\amp=0.5t^2-5t+12</mrow>
             <mrow>0\amp=0.5t^2-5t+12</mrow>
-            <mrow>\highlight{2\cdot}0\amp=\highlight{2\cdot}(0.5t^2-5t+12)\amp\text{removing leading coefficient}</mrow>
+            <mrow>\multiplyleft{2}0\amp=\multiplyleft{2}(0.5t^2-5t+12)\amp\text{removing leading coefficient}</mrow>
             <mrow>0\amp=t^2-10t+24</mrow>
             <mrow>-24\amp=t^2-10t</mrow>
-            <mrow>-24\highlight{+25}\amp=t^2-10t\highlight{+25}</mrow>
+            <mrow>-24\addright{25}\amp=t^2-10t\addright{25}</mrow>
             <mrow>1\amp=(t-5)^2</mrow>
             <mrow>\pm\sqrt{1}\amp=\sqrt{(t-5)^2}</mrow>
             <mrow>\pm1\amp=t-5</mrow>
@@ -103,7 +103,7 @@
                 <p>Step Two: By <m>x^2-2ax+a^2=(x-a)^2</m>, we have <m>s^2-10s+25=(s-5)^2</m>.</p>
                 <p>To solve the equation, we need to add <m>25</m> on both sides of the equation:<md>
                     <mrow>s^2-10s\amp=-34</mrow>
-                    <mrow>s^2-10s\highlight{+25}\amp=-34\highlight{+25}</mrow>
+                    <mrow>s^2-10s\addright{25}\amp=-34\addright{25}</mrow>
                     <mrow>(s-5)^2\amp=-9</mrow>
                 </md>Since the problem didn't say there are complex solutions, we conclude that there is no real solution.</p>
             </solution>
@@ -119,7 +119,7 @@
                 <p>Step Two: By <m>x^2-2ax+a^2=(x-a)^2</m>, we have <m>s^2-10s+25=(s-5)^2</m>.</p>
                 <p>To solve the equation, we need to add <m>25</m> on both sides of the equation:<md>
                     <mrow>s^2-10s\amp=-34</mrow>
-                    <mrow>s^2-10s\highlight{+25}\amp=-34\highlight{+25}</mrow>
+                    <mrow>s^2-10s\addright{25}\amp=-34\addright{25}</mrow>
                     <mrow>(s-5)^2\amp=-9</mrow>
                     <mrow>\sqrt{(s-5)^2}\amp=\pm\sqrt{-9}</mrow>
                     <mrow>s-5\amp=\pm\sqrt{9}\cdot\sqrt{-1}</mrow>

--- a/src/section-fractions.mbx
+++ b/src/section-fractions.mbx
@@ -565,12 +565,12 @@
 
         <example>
             <p>With our examples from the beginning of this subsection:<md>
-                <mrow>3\div\frac{2}{7}\amp=3\highlight{{}\cdot\frac{7}{2}}\amp\frac{18}{19}\div5\amp=\frac{18}{19}\div\frac{\highlight{5}}{\highlight{1}}</mrow>
-                <mrow>\amp=\frac{\highlight{3}}{\highlight{1}}\cdot\frac{7}{2}\amp\amp=\frac{18}{19}\highlight{{}\cdot\frac{1}{5}}</mrow>
+                <mrow>3\div\frac{2}{7}\amp=3\multiplyright{\frac{7}{2}}\amp\frac{18}{19}\div5\amp=\frac{18}{19}\div\divideunder{5}{1}</mrow>
+                <mrow>\amp=\divideunder{3}{1}\cdot\frac{7}{2}\amp\amp=\frac{18}{19}\multiplyright{\frac{1}{5}}</mrow>
                 <mrow>\amp=\frac{21}{2}\amp\amp=\frac{18}{95}</mrow>
                 <mrow></mrow>
-                <mrow>\frac{14}{3}\div\frac{8}{9}\amp=\frac{14}{3}\highlight{{}\cdot\frac{9}{8}}\amp\frac{\ \frac{2}{5}\ }{\frac{5}{2}}\amp=\frac{2}{5}\highlight{{}\div{}}\frac{5}{2}</mrow>
-                <mrow>\amp=\frac{14}{\highlight{1}}\cdot\frac{\highlight{3}}{8}\amp\amp=\frac{2}{5}\highlight{{}\cdot\frac{2}{5}}</mrow>
+                <mrow>\frac{14}{3}\div\frac{8}{9}\amp=\frac{14}{3}\multiplyright{\frac{9}{8}}\amp\frac{\ \frac{2}{5}\ }{\frac{5}{2}}\amp=\frac{2}{5}\highlight{{}\div{}}\frac{5}{2}</mrow>
+                <mrow>\amp=\frac{14}{\highlight{1}}\cdot\frac{\highlight{3}}{8}\amp\amp=\frac{2}{5}\multiplyright{\frac{2}{5}}</mrow>
                 <mrow>\amp=\frac{\highlight{7}}{1}\cdot\frac{3}{\highlight{4}}\amp\amp=\frac{4}{25}</mrow>
                 <mrow>\amp=\frac{21}{4}</mrow>
             </md></p>
@@ -722,7 +722,7 @@
 
         <example>
             <p>Let's add <m>\frac{2}{3}+\frac{2}{5}</m>. The denominators are <m>3</m> and <m>5</m>, so the number <m>15</m> would be a good common denominator.<md>
-                <mrow>\frac{2}{3}+\frac{2}{5}\amp=\frac{2\highlight{{}\cdot5}}{3\highlight{{}\cdot5}}+\frac{2\highlight{{}\cdot3}}{5\highlight{{}\cdot3}}</mrow>
+                <mrow>\frac{2}{3}+\frac{2}{5}\amp=\frac{2\multiplyright{5}}{3\multiplyright{5}}+\frac{2\multiplyright{3}}{5\multiplyright{3}}</mrow>
                 <mrow>\amp=\frac{10}{15}+\frac{6}{15}</mrow>
                 <mrow>\amp=\frac{21}{15}</mrow>
                 <mrow>\amp=\frac{7}{5}</mrow>

--- a/src/section-graphing-equations.mbx
+++ b/src/section-graphing-equations.mbx
@@ -42,12 +42,12 @@
         <caption />
         <p><md>
             <mrow>y\amp=-2x+3\amp\amp(x,y)</mrow>
-            <mrow>\hline\highlight{5}\amp\stackrel{\checkmark}{=}-2(\highlight{-1})+3\amp\amp(\highlight{-1},\highlight{5})</mrow>
-            <mrow>\highlight{3}\amp\stackrel{\checkmark}{=}-2(\highlight{0})+3\amp\amp(\highlight{0},\highlight{3})</mrow>
-            <mrow>\highlight{1}\amp\stackrel{\checkmark}{=}-2(\highlight{1})+3\amp\amp(\highlight{1},\highlight{1})</mrow>
-            <mrow>\highlight{-1}\amp\stackrel{\checkmark}{=}-2(\highlight{2})+3\amp\amp(\highlight{2},\highlight{-1})</mrow>
-            <mrow>\highlight{-3}\amp\stackrel{\checkmark}{=}-2(\highlight{3})+3\amp\amp(\highlight{3},\highlight{-3})</mrow>
-            <mrow>\highlight{-5}\amp\stackrel{\checkmark}{=}-2(\highlight{4})+3\amp\amp(\highlight{4},\highlight{-5})</mrow>
+            <mrow>\hline\substitute{5}\amp\stackrel{\checkmark}{=}-2(\substitute{-1})+3\amp\amp(\substitute{-1},\substitute{5})</mrow>
+            <mrow>\substitute{3}\amp\stackrel{\checkmark}{=}-2(\substitute{0})+3\amp\amp(\substitute{0},\substitute{3})</mrow>
+            <mrow>\substitute{1}\amp\stackrel{\checkmark}{=}-2(\substitute{1})+3\amp\amp(\substitute{1},\substitute{1})</mrow>
+            <mrow>\substitute{-1}\amp\stackrel{\checkmark}{=}-2(\substitute{2})+3\amp\amp(\substitute{2},\substitute{-1})</mrow>
+            <mrow>\substitute{-3}\amp\stackrel{\checkmark}{=}-2(\substitute{3})+3\amp\amp(\substitute{3},\substitute{-3})</mrow>
+            <mrow>\substitute{-5}\amp\stackrel{\checkmark}{=}-2(\substitute{4})+3\amp\amp(\substitute{4},\substitute{-5})</mrow>
         </md></p>
     </figure>
 
@@ -271,27 +271,27 @@
                     </row>
                     <row>
                         <cell><m>-2</m></cell>
-                        <cell><m>\phantom{-2(-2)+5=\highlight{9}}</m></cell>
+                        <cell><m>\phantom{-2(-2)+5=\substitute{9}}</m></cell>
                         <cell><m>\phantom{(-2,9)}</m></cell>
                     </row>
                     <row>
                         <cell><m>-1</m></cell>
-                        <cell><m>\phantom{-2(-1)+5=\highlight{7}}</m></cell>
+                        <cell><m>\phantom{-2(-1)+5=\substitute{7}}</m></cell>
                         <cell><m>\phantom{(-1,7)}</m></cell>
                     </row>
                     <row>
                         <cell><m>0</m></cell>
-                        <cell><m>\phantom{-2(0)+5=\highlight{5}}</m></cell>
+                        <cell><m>\phantom{-2(0)+5=\substitute{5}}</m></cell>
                         <cell><m>\phantom{(0,5)}</m></cell>
                     </row>
                     <row>
                         <cell><m>1</m></cell>
-                        <cell><m>\phantom{-2(1)+5=\highlight{3}}</m></cell>
+                        <cell><m>\phantom{-2(1)+5=\substitute{3}}</m></cell>
                         <cell><m>\phantom{(1,3)}</m></cell>
                     </row>
                     <row bottom="none">
                         <cell><m>2</m></cell>
-                        <cell><m>\phantom{-2(2)+5=\highlight{1}}</m></cell>
+                        <cell><m>\phantom{-2(2)+5=\substitute{1}}</m></cell>
                         <cell><m>\phantom{(2,1)}</m></cell>
                     </row>
                 </tabular>
@@ -309,27 +309,27 @@
                     </row>
                     <row>
                         <cell><m>-2</m></cell>
-                        <cell><m>-2(-2)+5=\highlight{9}</m></cell>
+                        <cell><m>-2(-2)+5=\substitute{9}</m></cell>
                         <cell><m>(-2,9)</m></cell>
                     </row>
                     <row>
                         <cell><m>-1</m></cell>
-                        <cell><m>-2(-1)+5=\highlight{7}</m></cell>
+                        <cell><m>-2(-1)+5=\substitute{7}</m></cell>
                         <cell><m>(-1,7)</m></cell>
                     </row>
                     <row>
                         <cell><m>0</m></cell>
-                        <cell><m>-2(0)+5=\highlight{5}</m></cell>
+                        <cell><m>-2(0)+5=\substitute{5}</m></cell>
                         <cell><m>(0,5)</m></cell>
                     </row>
                     <row>
                         <cell><m>1</m></cell>
-                        <cell><m>-2(1)+5=\highlight{3}</m></cell>
+                        <cell><m>-2(1)+5=\substitute{3}</m></cell>
                         <cell><m>(1,3)</m></cell>
                     </row>
                     <row bottom="none">
                         <cell><m>2</m></cell>
-                        <cell><m>-2(2)+5=\highlight{1}</m></cell>
+                        <cell><m>-2(2)+5=\substitute{1}</m></cell>
                         <cell><m>(2,1)</m></cell>
                     </row>
                 </tabular>

--- a/src/section-horizontal-vertical-parallel-and-perpendicular-lines.mbx
+++ b/src/section-horizontal-vertical-parallel-and-perpendicular-lines.mbx
@@ -97,9 +97,9 @@
         <p>We learned in <xref ref="section-standard-form">Section</xref> that all lines can be written in <xref ref="equation-standard-form" autoname="title">standard form</xref>. When either <m>A</m> or <m>B</m> equal <m>0</m>, we end up with a horizontal or vertical line, as we will soon see. Let's take the <xref ref="equation-standard-form" autoname="title">standard form</xref> line equation, let <m>A=0</m> and <m>B=0</m> one at a time and simplify each equation.</p>
         <p><md>
             <mrow>Ax+By\amp=C\amp Ax+By\amp=C</mrow>
-            <mrow>\highlight{0}x+By\amp=C\amp Ax+\highlight{0}y\amp=C</mrow>
+            <mrow>\substitute{0}x+By\amp=C\amp Ax+\substitute{0}y\amp=C</mrow>
             <mrow>By\amp=C\amp Ax\amp=C</mrow>
-            <mrow>y\amp=\frac{C}{\highlight{B}}\amp x\amp=\frac{C}{\highlight{A}}</mrow>
+            <mrow>y\amp=\divideunder{C}{B}\amp x\amp=\divideunder{C}{A}</mrow>
             <mrow>y\amp=k\amp x\amp=h</mrow>
         </md>At the end we just renamed the constant numbers <m>\frac{C}{B}</m> and <m>\frac{C}{A}</m> to <m>k</m> and <m>h</m> because of tradition. What is important, is that you view <m>h</m> and <m>k</m> (as well as <m>A</m>, <m>B</m>, and <m>C</m>) as constants: numbers that have some specific value and don't change in the context of one problem.</p>
 
@@ -837,9 +837,9 @@
                 <solution>
                     <p>First, we will find Line <m>A</m>'s slope by rewriting its equation from standard form to slope-intercept form:<md>
                         <mrow>2x+3y\amp=12</mrow>
-                        <mrow>3y\amp=12\highlight{{}-2x}</mrow>
+                        <mrow>3y\amp=12\subtractright{2x}</mrow>
                         <mrow>3y\amp=-2x+12</mrow>
-                        <mrow>y\amp=\frac{-2x+12}{\highlight{3}}</mrow>
+                        <mrow>y\amp=\divideunder{-2x+12}{3}</mrow>
                         <mrow>y\amp=-\frac{2}{3}x+4</mrow>
                     </md></p>
                     <p>So Line <m>A</m>'s slope is <m>-\frac{2}{3}\text{.}</m> Since Line <m>B</m> is perpendicular to Line <m>A</m>, its slope is <m>-\frac{1}{-\frac{2}{3}}=\frac{3}{2}</m>.</p>

--- a/src/section-introduction-to-radical-functions.mbx
+++ b/src/section-introduction-to-radical-functions.mbx
@@ -486,7 +486,7 @@
             <solution>
                 <p>We will solve for <m>r</m> in the formula <m>V(r)=\frac{4}{3}\pi r^3</m>:<md>
                     <mrow>V\amp=\frac{4}{3}\pi r^3</mrow>
-                    <mrow>\highlight{3\cdot}V\amp=\highlight{3\cdot}\frac{4}{3}\pi r^3</mrow>
+                    <mrow>\multiplyleft{3}V\amp=\multiplyleft{3}\frac{4}{3}\pi r^3</mrow>
                     <mrow>3V\amp=4\pi r^3</mrow>
                     <mrow>\frac{3V}{4\pi}\amp=\frac{4\pi r^3}{4\pi}</mrow>
                     <mrow>\frac{3V}{4\pi}\amp=r^3</mrow>

--- a/src/section-isolating-a-linear-variable.mbx
+++ b/src/section-isolating-a-linear-variable.mbx
@@ -68,7 +68,7 @@
                     <p>Scratch Paper Work
                         <md>
                             <mrow>1+b\amp=2</mrow>
-                            <mrow>1+b\highlight{{}-1}\amp=2\highlight{{}-1}</mrow>
+                            <mrow>1+b\subtractright{1}\amp=2\subtractright{1}</mrow>
                             <mrow>b\amp=2-1</mrow>
                         </md>
                     </p>
@@ -78,7 +78,7 @@
                     <p>Formal Solution
                         <md>
                             <mrow>x+b\amp=c</mrow>
-                            <mrow>x+b\highlight{{}-x}\amp=c\highlight{{}-x}</mrow>
+                            <mrow>x+b\subtractright{x}\amp=c\subtractright{x}</mrow>
                             <mrow>b\amp=c-x</mrow>
                         </md>
                     </p>
@@ -95,7 +95,7 @@
                     <p>Scratch Paper Work
                         <md>
                             <mrow>1\amp=2x+3</mrow>
-                            <mrow>1\highlight{{}-3}\amp=2x+3\highlight{{}-3}</mrow>
+                            <mrow>1\subtractright{3}\amp=2x+3\subtractright{3}</mrow>
                             <mrow>1-3\amp=2x</mrow>
                             <mrow>\frac{1-3}{2}\amp=\frac{2x}{2}</mrow>
                             <mrow>\frac{1-3}{2}\amp=x</mrow>
@@ -107,7 +107,7 @@
                     <p>Formal Solution
                         <md>
                             <mrow>y\amp=mx+b</mrow>
-                            <mrow>y\highlight{{}-b}\amp=mx+b\highlight{{}-b}</mrow>
+                            <mrow>y\subtractright{b}\amp=mx+b\subtractright{b}</mrow>
                             <mrow>y-b\amp=mx</mrow>
                             <mrow>\frac{y-b}{m}\amp=\frac{mx}{m}</mrow>
                             <mrow>\frac{y-b}{m}\amp=x</mrow>
@@ -124,7 +124,7 @@
                     <p>Scratch Paper Work
                         <md>
                             <mrow>1\amp=\frac{1}{2}b(3)</mrow>
-                            <mrow>\highlight{2\cdot{}}1\amp=\highlight{2\cdot{}}\frac{1}{2}b(3)</mrow>
+                            <mrow>\multiplyleft{2}1\amp=\multiplyleft{2}\frac{1}{2}b(3)</mrow>
                             <mrow>2\cdot1\amp=b(3)</mrow>
                             <mrow>\frac{2\cdot1}{3}\amp=\frac{3b}{3}</mrow>
                             <mrow>\frac{2\cdot1}{3}\amp=b</mrow>
@@ -136,7 +136,7 @@
                     <p>Formal Solution
                         <md>
                             <mrow>A\amp=\frac{1}{2}bh</mrow>
-                            <mrow>\highlight{2\cdot{}}A\amp=\highlight{2\cdot{}}\frac{1}{2}bh</mrow>
+                            <mrow>\multiplyleft{2}A\amp=\multiplyleft{2}\frac{1}{2}bh</mrow>
                             <mrow>2A\amp=bh</mrow>
                             <mrow>\frac{2A}{h}\amp=\frac{bh}{h}</mrow>
                             <mrow>\frac{2A}{h}\amp=b</mrow>
@@ -154,7 +154,7 @@
                     <p>Scratch Paper Work
                         <md>
                             <mrow>1\cdot2+3y\amp=4</mrow>
-                            <mrow>1\cdot2+3y\highlight{{}-1\cdot2}\amp=4\highlight{{}-1\cdot2}</mrow>
+                            <mrow>1\cdot2+3y\subtractright{1\cdot2}\amp=4\subtractright{1\cdot2}</mrow>
                             <mrow>3y\amp=4-1\cdot2</mrow>
                             <mrow>\frac{3y}{3}\amp=\frac{4-1\cdot2}{3}</mrow>
                             <mrow>y\amp=\frac{4-1\cdot2}{3}</mrow>
@@ -166,7 +166,7 @@
                     <p>Formal Solution
                         <md>
                             <mrow>Ax+By\amp=C</mrow>
-                            <mrow>Ax+By\highlight{{}-Ax}\amp=C\highlight{{}-Ax}</mrow>
+                            <mrow>Ax+By\subtractright{Ax}\amp=C\subtractright{Ax}</mrow>
                             <mrow>By\amp=C-Ax</mrow>
                             <mrow>\frac{By}{B}\amp=\frac{C-Ax}{B}</mrow>
                             <mrow>y\amp=\frac{C-Ax}{B}</mrow>

--- a/src/section-more-on-rationalizing-the-denominator.mbx
+++ b/src/section-more-on-rationalizing-the-denominator.mbx
@@ -31,7 +31,7 @@
         <title>Rationalizing the Denominator with Radicals of Higher Degrees</title>
 
         <p>To remove radicals from the denominator of <m>\frac{1}{\sqrt{2}}</m>, we multiply the numerator and denominator by <m>\sqrt{2}</m>, and we have:<md>
-            <mrow>\frac{1}{\sqrt{2}}\amp=\frac{1\highlight{\cdot\sqrt{2}}}{\sqrt{2}\highlight{\cdot\sqrt{2}}}</mrow>
+            <mrow>\frac{1}{\sqrt{2}}\amp=\frac{1\multiplyright{\sqrt{2}}}{\sqrt{2}\multiplyright{\sqrt{2}}}</mrow>
             <mrow>\amp=\frac{\sqrt{2}}{2}</mrow>
         </md>We used the property:<me>\sqrt{x}\cdot\sqrt{x}=x,\text{ where }x\text{ is positive}</me>In this section, we assume all variables are positive, so we don't need to use the absolute value symbols.</p>
 
@@ -48,7 +48,7 @@
             </statement>
             <solution>
                 <p>To remove the radical <m>\sqrt[3]{2}</m>, we will use the property <m>\sqrt[3]{2^3}=2</m>. This implies we will multiply the numerator and denominator by <m>\sqrt[3]{2^2}</m>:<md>
-                    <mrow>\frac{1}{\sqrt[3]{2}}\amp=\frac{1\highlight{\cdot\sqrt[3]{2^2}}}{\sqrt[3]{2}\highlight{\cdot\sqrt[3]{2^2}}}</mrow>
+                    <mrow>\frac{1}{\sqrt[3]{2}}\amp=\frac{1\multiplyright{\sqrt[3]{2^2}}}{\sqrt[3]{2}\multiplyright{\sqrt[3]{2^2}}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{2^2}}{\sqrt[3]{2^3}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{4}}{2}</mrow>
                 </md></p>
@@ -61,7 +61,7 @@
             </statement>
             <solution>
                 <p><md>
-                    <mrow>\frac{\sqrt{3}}{3\sqrt{2x}}\amp=\frac{\sqrt{3}\highlight{\cdot\sqrt{2x}}}{3\sqrt{2x}\highlight{\cdot\sqrt{2x}}}</mrow>
+                    <mrow>\frac{\sqrt{3}}{3\sqrt{2x}}\amp=\frac{\sqrt{3}\multiplyright{\sqrt{2x}}}{3\sqrt{2x}\multiplyright{\sqrt{2x}}}</mrow>
                     <mrow>\amp=\frac{\sqrt{3\cdot2x}}{3\cdot2x}</mrow>
                     <mrow>\amp=\frac{\sqrt{6x}}{6x}</mrow>
                 </md></p>
@@ -76,7 +76,7 @@
             </statement>
             <solution>
                 <p><md>
-                    <mrow>\frac{\sqrt[3]{y}}{3\sqrt[3]{2x}}\amp=\frac{\sqrt[3]{y}\highlight{\cdot\sqrt[3]{2^2x^2}}}{3\sqrt[3]{2x}\highlight{\cdot\sqrt[3]{2^2x^2}}}</mrow>
+                    <mrow>\frac{\sqrt[3]{y}}{3\sqrt[3]{2x}}\amp=\frac{\sqrt[3]{y}\multiplyright{\sqrt[3]{2^2x^2}}}{3\sqrt[3]{2x}\multiplyright{\sqrt[3]{2^2x^2}}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{4x^2y}}{3\cdot2x}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{4x^2y}}{6x}</mrow>
                 </md></p>
@@ -92,7 +92,7 @@
             <solution>
                 <p><md>
                     <mrow>\sqrt[3]{\frac{2}{3}}\amp=\frac{\sqrt[3]{2}}{\sqrt[3]{3}}</mrow>
-                    <mrow>\amp=\frac{\sqrt[3]{2}\highlight{\cdot\sqrt{3^2}}}{\sqrt[3]{3}\highlight{\cdot\sqrt{3^2}}}</mrow>
+                    <mrow>\amp=\frac{\sqrt[3]{2}\multiplyright{\sqrt{3^2}}}{\sqrt[3]{3}\multiplyright{\sqrt{3^2}}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{2\cdot3^2}}{3}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{18}}{3}</mrow>
                 </md></p>
@@ -106,7 +106,7 @@
             <solution>
                 <p><md>
                     <mrow>\sqrt[3]{\frac{r}{s^2}}\amp=\frac{\sqrt[3]{r}}{\sqrt[3]{s^2}}</mrow>
-                    <mrow>\amp=\frac{\sqrt[3]{r}\highlight{\cdot\sqrt[3]{s}}}{\sqrt[3]{s^2}\highlight{\cdot\sqrt[3]{s}}}</mrow>
+                    <mrow>\amp=\frac{\sqrt[3]{r}\multiplyright{\sqrt[3]{s}}}{\sqrt[3]{s^2}\multiplyright{\sqrt[3]{s}}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{rs}}{s}</mrow>
                 </md></p>
             </solution>
@@ -122,7 +122,7 @@
                 <p><md>
                     <mrow>\frac{1}{\sqrt[3]{54x^5}}\amp=\frac{1}{\sqrt[3]{2\cdot3^3x^3x^2}}</mrow>
                     <mrow>\amp=\frac{1}{3x\cdot\sqrt[3]{2x^2}}</mrow>
-                    <mrow>\amp=\frac{1\highlight{\cdot\sqrt[3]{2^2x}}}{3x\cdot\sqrt[3]{2x^2}\highlight{\cdot\sqrt[3]{2^2x}}}</mrow>
+                    <mrow>\amp=\frac{1\multiplyright{\sqrt[3]{2^2x}}}{3x\cdot\sqrt[3]{2x^2}\multiplyright{\sqrt[3]{2^2x}}}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{2^2x}}{3x\cdot2x}</mrow>
                     <mrow>\amp=\frac{\sqrt[3]{4x}}{6x^2}</mrow>
                 </md></p>
@@ -199,7 +199,7 @@
         <title>Rationalize Denominator with Difference of Squares Formula</title>
 
         <p>How can be remove the radical in the denominator of <m>\frac{1}{\sqrt{2}+1}</m>? Let's try by multiplying the numerator and denominator by <m>\sqrt{2}</m>:<md>
-            <mrow>\frac{1}{\sqrt{2}+1}\amp=\frac{1\highlight{\cdot\sqrt{2}}}{(\sqrt{2}+1)\highlight{\cdot\sqrt{2}}}</mrow>
+            <mrow>\frac{1}{\sqrt{2}+1}\amp=\frac{1\multiplyright{\sqrt{2}}}{(\sqrt{2}+1)\multiplyright{\sqrt{2}}}</mrow>
             <mrow>\amp=\frac{\sqrt{2}}{\sqrt{2}\cdot\sqrt{2}+1\cdot\sqrt{2}}</mrow>
             <mrow>\amp=\frac{\sqrt{2}}{2+\sqrt{2}}</mrow>
         </md>We removed one radical in the denominator, but created another. We need to find another method, using the Difference of Squares formula:<me>(a+b)(a-b)=a^2-b^2</me>Those two squares in <m>a^2-b^2</m> will remove square roots. To remove the radical in <m>\sqrt{2}+1</m> with the Difference of Squares formula, we will multiply it with <m>\sqrt{2}-1</m>, and we have:<md>
@@ -207,7 +207,7 @@
             <mrow>\amp=2-1</mrow>
             <mrow>\amp=1</mrow>
         </md>To remove the radical in the denominator of <m>\frac{1}{\sqrt{2}+1}</m>, we multiply the numerator and denominator by <m>\sqrt{2}-1</m>:<md>
-            <mrow>\frac{1}{\sqrt{2}+1}\amp=\frac{1\highlight{\cdot(\sqrt{2}-1)}}{(\sqrt{2}+1)\highlight{\cdot(\sqrt{2}-1)}}</mrow>
+            <mrow>\frac{1}{\sqrt{2}+1}\amp=\frac{1\multiplyright{(\sqrt{2}-1)}}{(\sqrt{2}+1)\multiplyright{(\sqrt{2}-1)}}</mrow>
             <mrow>\amp=\frac{\sqrt{2}-1}{(\sqrt{2})^2-(1)^2}</mrow>
             <mrow>\amp=\frac{\sqrt{2}-1}{2-1}</mrow>
             <mrow>\amp=\frac{\sqrt{2}-1}{1}</mrow>
@@ -220,7 +220,7 @@
             </statement>
             <solution>
                 <p>To remove radicals in <m>\sqrt{5}+\sqrt{3}</m> with the Difference of Squares formula, we multiply it with <m>\sqrt{5}-\sqrt{3}</m>. The solution is:<md>
-                    <mrow>\frac{\sqrt{5}-\sqrt{3}}{\sqrt{5}+\sqrt{3}}\amp=\frac{(\sqrt{5}-\sqrt{3})\highlight{\cdot(\sqrt{5}-\sqrt{3})}}{(\sqrt{5}+\sqrt{3})\highlight{\cdot(\sqrt{5}-\sqrt{3})}}</mrow>
+                    <mrow>\frac{\sqrt{5}-\sqrt{3}}{\sqrt{5}+\sqrt{3}}\amp=\frac{(\sqrt{5}-\sqrt{3})\multiplyright{(\sqrt{5}-\sqrt{3})}}{(\sqrt{5}+\sqrt{3})\multiplyright{(\sqrt{5}-\sqrt{3})}}</mrow>
                     <mrow>\amp=\frac{\sqrt{5}\cdot\sqrt{5}-\sqrt{5}\cdot\sqrt{3}-\sqrt{3}\cdot\sqrt{5}+(-\sqrt{3})(-\sqrt{3})}{(\sqrt{5})^2-(\sqrt{3})^2}</mrow>
                     <mrow>\amp=\frac{5-\sqrt{15}-\sqrt{15}+3}{5-3}</mrow>
                     <mrow>\amp=\frac{8-2\sqrt{15}}{2}</mrow>
@@ -236,7 +236,7 @@
             </statement>
             <solution>
                 <p>To remove the radical in <m>3-2\sqrt{3}</m> with the Difference of Squares formula, we multiply it with <m>3+2\sqrt{3}</m>. The solution is:<md>
-                    <mrow>\frac{\sqrt{3}}{3-2\sqrt{3}}\amp=\frac{\sqrt{3}\highlight{\cdot(3+2\sqrt{3})}}{(3-2\sqrt{3})\highlight{\cdot(3+2\sqrt{3})}}</mrow>
+                    <mrow>\frac{\sqrt{3}}{3-2\sqrt{3}}\amp=\frac{\sqrt{3}\multiplyright{(3+2\sqrt{3})}}{(3-2\sqrt{3})\multiplyright{(3+2\sqrt{3})}}</mrow>
                     <mrow>\amp=\frac{3\sqrt{3}+2\sqrt{3}\cdot\sqrt{3}}{(3)^2-(2\sqrt{3})^2}</mrow>
                     <mrow>\amp=\frac{3\sqrt{3}+2\cdot3}{9-2^2(\sqrt{3})^2}</mrow>
                     <mrow>\amp=\frac{3\sqrt{3}+6}{9-4(3)}</mrow>
@@ -254,7 +254,7 @@
             </statement>
             <solution>
                 <p>To remove radicals in <m>\sqrt{m}-\sqrt{n}</m> with the Difference of Squares formula, we multiply it with <m>\sqrt{m}+\sqrt{n}</m>. The solution is:<md>
-                    <mrow>\frac{\sqrt{m}+\sqrt{n}}{\sqrt{m}-\sqrt{n}}\amp=\frac{(\sqrt{m}+\sqrt{n})\highlight{\cdot(\sqrt{m}+\sqrt{n})}}{(\sqrt{m}-\sqrt{n})\highlight{\cdot(\sqrt{m}+\sqrt{n})}}</mrow>
+                    <mrow>\frac{\sqrt{m}+\sqrt{n}}{\sqrt{m}-\sqrt{n}}\amp=\frac{(\sqrt{m}+\sqrt{n})\multiplyright{(\sqrt{m}+\sqrt{n})}}{(\sqrt{m}-\sqrt{n})\multiplyright{(\sqrt{m}+\sqrt{n})}}</mrow>
                     <mrow>\amp=\frac{\sqrt{m}\cdot\sqrt{m}+\sqrt{m}\cdot\sqrt{n}+\sqrt{n}\cdot\sqrt{m}+\sqrt{n}\cdot\sqrt{n}}{(\sqrt{m})^2-(\sqrt{n})^2}</mrow>
                     <mrow>\amp=\frac{m+\sqrt{mn}+\sqrt{mn}+n}{m-n}</mrow>
                     <mrow>\amp=\frac{m+2\sqrt{mn}+n}{m-n}</mrow>

--- a/src/section-point-slope-form.mbx
+++ b/src/section-point-slope-form.mbx
@@ -46,8 +46,8 @@
             </ol></p>
             <p>If we use the generic <m>(x,y)</m> to represent a point <em>somewhere</em> on this line, then the rate of change between <m>(1990,253)</m> and <m>(x,y)</m> has to be <m>2.865</m>. So <me>\frac{y-253}{x-1990}=2.865\text{.}</me> There is good reason<fn>It will help us to see that <m>y</m> (population) <em>depends</em> on <m>x</m> (whatever year it is).</fn> to want to isolate <m>y</m> in this equation:<md>
                 <mrow>\frac{y-253}{x-1990}\amp=2.865</mrow>
-                <mrow>y-253\amp=2.865\highlight{(x-1990)}\amp\amp\text{(could distribute, but not gonna)}</mrow>
-                <mrow>y\amp=2.865(x-1990)\highlight{{}+253}</mrow>
+                <mrow>y-253\amp=2.865\multiplyright{(x-1990)}\amp\amp\text{(could distribute, but not gonna)}</mrow>
+                <mrow>y\amp=2.865(x-1990)\addright{253}</mrow>
             </md></p>
             <p>This is a good place to stop. We have isolated <m>y</m>, and three <em>meaningful</em> numbers appear in the population: the rate of growth, a certain year, and the population in that year. This is a specific example of <term>point-slope form</term>.</p>
         </example>
@@ -166,12 +166,12 @@
 
             <p>We're ready to answer the question about when the chain might go out of business. Substitute <m>y</m> in the equation with <m>1800</m> and solve for <m>x\text{,}</m> and we will get the answer we seek.<md>
                 <mrow>y\amp=-130(x-2013)+2975</mrow>
-                <mrow>\highlight{1800}\amp=-130(x-2013)+2975</mrow>
-                <mrow>1800\highlight{{}-2975}\amp=-130(x-2013)</mrow>
+                <mrow>\substitute{1800}\amp=-130(x-2013)+2975</mrow>
+                <mrow>1800\subtractright{2975}\amp=-130(x-2013)</mrow>
                 <mrow>-1175\amp-130(x-2013)</mrow>
-                <mrow>\frac{-1175}{\highlight{-130}}\amp=x-2013</mrow>
+                <mrow>\divideunder{-1175}{-130}\amp=x-2013</mrow>
                 <mrow>9.038\approx\amp=x-2013</mrow>
-                <mrow>9.038\highlight{{}+2013}\amp\approx x</mrow>
+                <mrow>9.038\addright{2013}\amp\approx x</mrow>
                 <mrow>2022\amp\approx x</mrow>
             </md>And so we find that at this rate, the company is headed toward a collapse in 2022.</p>
         </example>

--- a/src/section-radical-expression-operations.mbx
+++ b/src/section-radical-expression-operations.mbx
@@ -277,7 +277,7 @@
                     <mrow>\sqrt{\frac{3}{4}}+\sqrt{12}\amp=\frac{\sqrt{3}}{\sqrt{4}}+\sqrt{2^2\cdot3}</mrow>
                     <mrow>\amp=\frac{\sqrt{3}}{2}+2\sqrt{3}</mrow>
                     <mrow>\amp=\frac{\sqrt{3}}{2}+\frac{2\sqrt{3}}{1}</mrow>
-                    <mrow>\amp=\frac{\sqrt{3}}{2}+\frac{\highlight{2\cdot}2\sqrt{3}}{\highlight{2\cdot}1}</mrow>
+                    <mrow>\amp=\frac{\sqrt{3}}{2}+\frac{\multiplyleft{2}2\sqrt{3}}{\multiplyleft{2}1}</mrow>
                     <mrow>\amp=\frac{\sqrt{3}}{2}+\frac{4\sqrt{3}}{2}</mrow>
                     <mrow>\amp=\frac{\sqrt{3}+4\sqrt{3}}{2}</mrow>
                     <mrow>\amp=\frac{5\sqrt{3}}{2}</mrow>

--- a/src/section-review-of-solving-quadratic-equations.mbx
+++ b/src/section-review-of-solving-quadratic-equations.mbx
@@ -70,13 +70,13 @@
             <solution>
                 <p><md>
                     <mrow>-40\amp=10-2(p-1)^2</mrow>
-                    <mrow>-40\highlight{-10}\amp=10-2(p-1)^2\highlight{-10}</mrow>
+                    <mrow>-40\subtractright{10}\amp=10-2(p-1)^2\subtractright{10}</mrow>
                     <mrow>-50\amp=-2(p-1)^2</mrow>
                     <mrow>\frac{-50}{-2}\amp=\frac{-2(p-1)^2}{-2}</mrow>
                     <mrow>25\amp=(p-1)^2</mrow>
                     <mrow>\pm\sqrt{25}\amp=\sqrt{(p-1)^2}</mrow>
                     <mrow>\pm5\amp=p-1</mrow>
-                    <mrow>\pm5\highlight{+1}\amp=p-1\highlight{+1}</mrow>
+                    <mrow>\pm5\addright{1}\amp=p-1\addright{1}</mrow>
                     <mrow>\pm5+1\amp=p</mrow>
                     <mrow>p=5+1\amp\text{ or }p=-5+1</mrow>
                     <mrow>p=6\amp\text{ or }p=-4</mrow>
@@ -131,7 +131,7 @@
             <solution>
                 <p>Again, we must make the equation's right side <m>0</m>, so we can factor and use Zero Product Property.<md>
                     <mrow>(x+4)(x-3)\amp=18</mrow>
-                    <mrow>(x+4)(x-3)\highlight{-18}\amp=18\highlight{-18}</mrow>
+                    <mrow>(x+4)(x-3)\subtractright{18}\amp=18\subtractright{18}</mrow>
                     <mrow>(x+4)(x-3)-18\amp=0</mrow>
                     <mrow>x^2+x-12-18\amp=0</mrow>
                     <mrow>x^2+x-30\amp=0</mrow>
@@ -170,7 +170,7 @@
             <solution>
                 <p>First, we convert the equation into standard form:<md>
                     <mrow>4x^2+9\amp=12x</mrow>
-                    <mrow>4x^2+9\highlight{-12x}\amp=12x\highlight{-12x}</mrow>
+                    <mrow>4x^2+9\subtractright{12x}\amp=12x\subtractright{12x}</mrow>
                     <mrow>4x^2-12x+9\amp=0</mrow>
                 </md>Now we can identify that <m>a=4</m>, <m>b=-12</m> and <m>c=9</m>. We will substitute them into the Quadratic Formula:<md>
                     <mrow>x\amp=\frac{-b\pm\sqrt{b^2-4ac}}{2a}</mrow>

--- a/src/section-slope-intercept-form.mbx
+++ b/src/section-slope-intercept-form.mbx
@@ -437,10 +437,10 @@
                     </table>
                     <p>This tells us the initial <m>y</m>-value is <m>4</m>.</p>
                     <p>Alternatively, we can use any one point that we know the line passes through, and use algebra to solve for <m>b</m>. We know the line passes through <m>(3,-2)</m>, so<md>
-                        <mrow>y\amp=-2x+b</mrow> 
-                        <mrow>\highlight{-2}\amp=-2(\highlight{3})+b</mrow> 
-                        <mrow>-2\amp=-6+b</mrow> 
-                        <mrow>4\amp=b</mrow> 
+                        <mrow>y\amp=-2x+b</mrow>
+                        <mrow>\substitute{-2}\amp=-2(\substitute{3})+b</mrow>
+                        <mrow>-2\amp=-6+b</mrow>
+                        <mrow>4\amp=b</mrow>
                     </md></p>
                     <p>So the equation is <m>y=-2x+4</m>.</p>
                 </solution>
@@ -867,17 +867,17 @@
 
                 <p>If a trip is <m>5</m> miles long, we substitute <m>x=5</m> into the equation and we have:<md>
                     <mrow>y\amp=3.85x+7.35</mrow>
-                    <mrow>\amp=3.85(\highlight{5})+7.35</mrow>
+                    <mrow>\amp=3.85(\substitute{5})+7.35</mrow>
                     <mrow>\amp=19.25+7.35</mrow>
                     <mrow>\amp=26.60</mrow>
                 </md>And the <m>5</m>-mile ride will cost you about <m>\$26.60</m>. (We say <q>about,</q> because this was all assuming you average <quantity><mag>30</mag><unit base="mileperhour" /></quantity>.)</p>
 
                 <p>Next, to find how long of a trip would cost <m>\$100\text{,}</m> we substitute <m>y=100</m> into the equation and solve for <m>x</m>:<md>
                     <mrow>y\amp=3.85x+7.35</mrow>
-                    <mrow>\highlight{100}\amp=3.85x+7.35</mrow>
-                    <mrow>100\highlight{{}-7.35}\amp=3.85x</mrow>
+                    <mrow>\substitute{100}\amp=3.85x+7.35</mrow>
+                    <mrow>100\subtractright{7.35}\amp=3.85x</mrow>
                     <mrow>92.65\amp=3.85x</mrow>
-                    <mrow>\frac{92.65}{\highlight{3.85}}\amp=x</mrow>
+                    <mrow>\divideunder{92.65}{3.85}\amp=x</mrow>
                     <mrow>24.06\amp\approx x</mrow>
                 </md>So with <m>\$100</m> you could afford a little more than a <m>24</m>-mile trip.</p>
             </solution>
@@ -910,17 +910,17 @@
 
                     <p>To estimate the elephant population <m>15</m> years later, we substitute <m>x</m> in the equation with <m>15\text{,}</m> and we have:<md>
                         <mrow>y\amp=-30x+2400</mrow>
-                        <mrow>\amp=-30(\highlight{15})+2400</mrow>
+                        <mrow>\amp=-30(\substitute{15})+2400</mrow>
                         <mrow>\amp=-450+2400</mrow>
                         <mrow>\amp=1950</mrow>
                     </md>So if the trend continues, there would be <m>1950</m> elephants on this reservation 15 years later.</p>
 
                     <p>Next, to find when the elephant population would decrease to <m>1200\text{,}</m> we substitute <m>y</m> in the equation with <m>1200\text{,}</m> and solve for <m>x</m>:<md>
                         <mrow>y\amp=-30x+2400</mrow>
-                        <mrow>\highlight{1200}\amp=-30x+2400</mrow>
-                        <mrow>1200\highlight{{}-2400}\amp=-30x</mrow>
+                        <mrow>\substitute{1200}\amp=-30x+2400</mrow>
+                        <mrow>1200\subtractright{2400}\amp=-30x</mrow>
                         <mrow>-1200\amp=-30x</mrow>
-                        <mrow>\frac{-1200}{\highlight{-30}}\amp=x</mrow>
+                        <mrow>\divideunder{-1200}{-30}\amp=x</mrow>
                         <mrow>40\amp=x</mrow>
                     </md>So if the trend continues, <m>40</m> years later, the elephant population would dwindle to <m>1,200\text{.}</m></p>
                 </solution>

--- a/src/section-solving-linear-equations-and-inequalities-with-fractions.mbx
+++ b/src/section-solving-linear-equations-and-inequalities-with-fractions.mbx
@@ -33,13 +33,13 @@
         <p>So far, in our last step of solving for a variable we have divided each side of the equation by a constant, as in:
             <md>
                 <mrow>2x\amp=10</mrow>
-                <mrow>\frac{2x}{\highlight{{} 2}} \amp= \frac{10}{\highlight{{} 2}}</mrow>
+                <mrow>\divideunder{2x}{2} \amp= \divideunder{10}{2}</mrow>
                 <mrow>x\amp=5</mrow>
             </md>
         If we instead have a coefficient that is a fraction, we could proceed in exactly the same manner:
             <md>
                 <mrow>\frac{1}{2}x\amp=10</mrow>
-                <mrow>\frac{\frac{1}{2}x}{\highlight{{} \frac{1}{2}}} \amp= \frac{10}{\highlight{{} \frac{1}{2}}}</mrow>
+                <mrow>\divideunder{\frac{1}{2}x}{\frac{1}{2}} \amp= \divideunder{10}{\frac{1}{2}}</mrow>
                 <mrow>x\amp=10\cdot \frac{2}{1}</mrow>
                 <mrow>x\amp=20</mrow>
             </md>
@@ -47,7 +47,7 @@
         What if our equation or inequality was more complicated though, for example <m>\frac{1}{4}x+\frac{2}{3}=\frac{1}{6}</m>? We would have to first do a lot of fraction arithmetic in order to then divide each side by the coefficient on <m>x</m>. An alternate approach is to instead <em>multiply</em> each side of the equation by a chosen constant that eliminates the denominator. In the equation <m>\frac{1}{2}x=10</m>, we could simply multiply each side of the equation by <m>2</m>, which would eliminate the denominator of <m>2</m>:
             <md>
                 <mrow>\frac{1}{2}x\amp=10</mrow>
-                <mrow>\highlight{2\cdot{}}\left(\frac{1}{2}x\right)\amp=\highlight{2\cdot{}}10</mrow>
+                <mrow>\multiplyleft{2}\left(\frac{1}{2}x\right)\amp=\multiplyleft{2}10</mrow>
                 <mrow>x\amp=20</mrow>
             </md>
         For more complicated equations, we will multiply each side of the equation by the least common denominator (LCD) of all fractions contained in the equation.</p>
@@ -56,14 +56,14 @@
 
         <p>Another skill we need to learn is that we can multiply both sides of an equation (divided by the equal sign) with the same number. Let's look at an example.<md>
             <mrow>1+2\amp=3</mrow>
-            <mrow>\highlight{2\cdot{}}(1+2)\amp=\highlight{2\cdot{}}3</mrow>
+            <mrow>\multiplyleft{2}(1+2)\amp=\multiplyleft{2}3</mrow>
             <mrow>2\cdot1+2\cdot2\amp=6</mrow>
             <mrow>2+4\amp=6</mrow>
         </md></p>
 
         <p>Let's try another number:<md>
             <mrow>1+2\amp=3</mrow>
-            <mrow>\highlight{3\cdot{}}(1+2)\amp=\highlight{3\cdot{}}3</mrow>
+            <mrow>\multiplyleft{3}(1+2)\amp=\multiplyleft{3}3</mrow>
             <mrow>3\cdot1+3\cdot2\amp=9</mrow>
             <mrow>3+6\amp=9</mrow>
         </md></p>
@@ -83,36 +83,36 @@
 
         <p>When we use this property, we must not miss any number when we do multiplication; otherwise the equation will <em>not</em> hold. Here is an example of a mistake:<md>
             <mrow>1+2\amp=3</mrow>
-            <mrow>\highlight{2\cdot{}}1+2\amp=\highlight{2\cdot{}}3\amp\text{incorrect!}</mrow>
+            <mrow>\multiplyleft{2}1+2\amp=\multiplyleft{2}3\amp\text{incorrect!}</mrow>
             <mrow>2+2\amp=6</mrow>
         </md></p>
 
-        <p>We should have done: <m>\highlight{2\cdot{}}(1+2)=\highlight{2\cdot{}}3</m>.</p>
+        <p>We should have done: <m>\multiplyleft{2}(1+2)=\multiplyleft{2}3</m>.</p>
 
         <p>If two numbers or variables are joined by multiplication, they are considered as one term in an equation. For example, in <m>2\cdot3=6</m>, the term <m>2\cdot3</m> is considered as one term. If we treat them as two terms and use the multiplication property, the equation will <em>not</em> hold:<md>
             <mrow>2\cdot3\amp=6</mrow>
-            <mrow>(\highlight{2\cdot{}}2)\cdot(\highlight{2\cdot{}}3)\amp=\highlight{2\cdot{}}6\amp\text{incorrect!}</mrow>
+            <mrow>(\multiplyleft{2}2)\cdot(\multiplyleft{2}3)\amp=\multiplyleft{2}6\amp\text{incorrect!}</mrow>
             <mrow>4\cdot6\amp=12</mrow>
             <mrow>24\amp=12</mrow>
         </md></p>
 
         <p>The correct thing to do is:<md>
             <mrow>2\cdot3\amp=6</mrow>
-            <mrow>\highlight{2\cdot{}}(2\cdot3)\amp=\highlight{2\cdot{}}6</mrow>
+            <mrow>\multiplyleft{2}(2\cdot3)\amp=\multiplyleft{2}6</mrow>
             <mrow>2\cdot6\amp=12</mrow>
             <mrow>12\amp=12</mrow>
         </md></p>
 
         <p>Later, when we try to remove fractions in an equation like <m>4+\frac{1}{2}(x+1)=3</m>, we will do:<md>
             <mrow>4+\frac{1}{2}(x+1)\amp=3</mrow>
-            <mrow>\highlight{2\cdot{}}[4+\frac{1}{2}(x+1)]\amp=\highlight{2\cdot{}}3</mrow>
+            <mrow>\multiplyleft{2}[4+\frac{1}{2}(x+1)]\amp=\multiplyleft{2}3</mrow>
             <mrow>2\cdot4+2\cdot\frac{1}{2}(x+1)]\amp=6</mrow>
             <mrow>8+(x+1)\amp=6</mrow>
             <mrow>\ldots</mrow>
         </md></p>
 
         <p>Note that <m>\frac{1}{2}(x+1)</m> is considered one term because they are joined by multiplication. We will <em>not</em> do:<md>
-            <mrow>\highlight{2\cdot{}}[4+\frac{1}{2}(x+1)]\amp=\highlight{2\cdot{}}3</mrow>
+            <mrow>\multiplyleft{2}[4+\frac{1}{2}(x+1)]\amp=\multiplyleft{2}3</mrow>
             <mrow>2\cdot4+2\cdot\frac{1}{2}\cdot2\cdot(x+1)]\amp=6\amp\text{incorrect!}</mrow>
         </md></p>
 -->
@@ -167,7 +167,7 @@
                 <p>From this, we've determined that <m>y</m> years since the tree was planted, the tree's height will be <m>\frac{2}{3}y+4</m> feet. To find when the tree will be <m>10</m> feet tall, we write and solve this equation:
                     <md>
                         <mrow>\frac{2}{3}y+4\amp=10</mrow>
-                        <mrow>\highlight{3\cdot{}}(\frac{2}{3}y+4)\amp=\highlight{3\cdot{}}10</mrow>
+                        <mrow>\multiplyleft{3}(\frac{2}{3}y+4)\amp=\multiplyleft{3}10</mrow>
                         <mrow>3\cdot\frac{2}{3}y+3\cdot4\amp=30</mrow>
                         <mrow>2y+12\amp=30</mrow>
                         <mrow>2y\amp=18</mrow>
@@ -206,7 +206,7 @@
                 <p>Assume the length of the house is <m>l</m> feet long. By the given condition, we can write the equation <m>\frac{2}{3}l+3=27</m>. To eliminate the denominator of <m>3</m>, we will multiply each side of the equation by <m>3</m>:
                     <md>
                         <mrow>\frac{2}{3}l+3\amp=27</mrow>
-                        <mrow>\highlight{3\cdot{}}\left(\frac{2}{3}l+3\right)\amp=\highlight{3\cdot{}}27</mrow>
+                        <mrow>\multiplyleft{3}\left(\frac{2}{3}l+3\right)\amp=\multiplyleft{3}27</mrow>
                         <mrow>3\cdot\frac{2}{3}l+3\cdot3\amp=81</mrow>
                         <mrow>2l+9\amp=81</mrow>
                         <mrow>2l\amp=72</mrow>
@@ -259,11 +259,11 @@
                 <p>To solve this equation, we first need to identify the LCD of all fractions in the equation. On the left side we have <m>\frac{1}{4}</m> and <m>\frac{2}{3}</m>. On the right side we have <m>\frac{1}{6}</m>. The LCD of <m>3, 4</m>, and <m>6</m> is <m>12</m>, so we will multiply each side of the equation by <m>12</m> in order to eliminate <em>all</em> of the denominators:
                     <md>
                         <mrow>\frac{1}{4}x+\frac{2}{3}\amp=\frac{1}{6}</mrow>
-                        <mrow>\highlight{12\cdot{}}\left(\frac{1}{4}x+\frac{2}{3}\right)\amp=\highlight{12\cdot{}}\frac{1}{6}</mrow>
+                        <mrow>\multiplyleft{12}\left(\frac{1}{4}x+\frac{2}{3}\right)\amp=\multiplyleft{12}\frac{1}{6}</mrow>
                         <mrow>12\cdot\left(\frac{1}{4}x\right)+12\cdot\left(\frac{2}{3}\right)\amp=12\cdot\frac{1}{6} \amp\text{The 12 is distributed across addition}</mrow>
                         <mrow>3x+8\amp=2</mrow>
                         <mrow>3x\amp=-6</mrow>
-                        <mrow>\frac{3x}{\highlight{{} 3}}\amp=\frac{-6}{\highlight{{} 3}}</mrow>
+                        <mrow>\divideunder{3x}{3}\amp=\divideunder{-6}{3}</mrow>
                         <mrow>x\amp=-2</mrow>
                     </md>
                 </p>
@@ -298,7 +298,7 @@
                 <p>The first thing we need to do is identify the LCD of all denmoinators in this equation. Since the denominators are <m>2</m> and <m>5</m>, the LCD is <m>10</m>. So as our first step, we will multiply each side of the equation by <m>10</m> in order to eliminate all denominators:
                     <md>
                         <mrow>-\frac{2}{5}z-\frac{3}{2}\amp=-\frac{1}{2}z+\frac{4}{5}</mrow>
-                        <mrow>\highlight{10\cdot{}}\left(-\frac{2}{5}z-\frac{3}{2}\right)\amp=\highlight{10\cdot{}}\left(-\frac{1}{2}z+\frac{4}{5}\right)</mrow>
+                        <mrow>\multiplyleft{10}\left(-\frac{2}{5}z-\frac{3}{2}\right)\amp=\multiplyleft{10}\left(-\frac{1}{2}z+\frac{4}{5}\right)</mrow>
                         <mrow>10\left(-\frac{2}{5}z\right)-10\left(\frac{3}{2}\right)\amp=10\left(-\frac{1}{2}z\right)+10\left(\frac{4}{5}\right)</mrow>
                         <mrow>-4z-15\amp=-5z+8</mrow>
                         <mrow>z-15\amp=8</mrow>
@@ -336,7 +336,7 @@
                 <p>
                     <md>
                         <mrow>\frac{2}{3}(a+1)+5\amp=\frac{1}{3}</mrow>
-                        <mrow>\highlight{3\cdot{}}\left(\frac{2}{3}(a+1)+5\right)\amp=\highlight{3\cdot{}}\frac{1}{3}</mrow>
+                        <mrow>\multiplyleft{3}\left(\frac{2}{3}(a+1)+5\right)\amp=\multiplyleft{3}\frac{1}{3}</mrow>
                         <mrow>3\cdot\frac{2}{3}(a+1)+3\cdot5\amp=1</mrow>
                         <mrow>2(a+1)+15\amp=1</mrow>
                         <mrow>2a+2+15\amp=1</mrow>
@@ -375,7 +375,7 @@
                 <p>
                     <md>
                         <mrow>\frac{2b+1}{3}\amp=\frac{2}{5}</mrow>
-                        <mrow>\highlight{15\cdot{}}\frac{2b+1}{3}\amp=\highlight{15\cdot{}}\frac{2}{5}</mrow>
+                        <mrow>\multiplyleft{15}\frac{2b+1}{3}\amp=\multiplyleft{15}\frac{2}{5}</mrow>
                         <mrow>5(2b+1)\amp=6</mrow>
                         <mrow>10b+5\amp=6</mrow>
                         <mrow>10b\amp=1</mrow>
@@ -417,7 +417,7 @@
             <p>With this property, we can go from <m>\frac{2b+1}{3}=\frac{2}{5}</m> directly to <m>(2b+1)\cdot5=3\cdot2</m>, saving the second step. This property can be verified using the same process of eliminating the denominator by multiplying each side of the equation by the LCD (which in this case is <m>bd</m>):
                 <md>
                     <mrow>\frac{a}{b}\amp=\frac{c}{d}</mrow>
-                    <mrow>\highlight{bd\cdot{}}\frac{a}{b}\amp=\highlight{bd\cdot{}}\frac{c}{d}</mrow>
+                    <mrow>\multiplyleft{bd}\frac{a}{b}\amp=\multiplyleft{bd}\frac{c}{d}</mrow>
                     <mrow>ad\amp=bc</mrow>
                 </md>
             </p>
@@ -439,10 +439,10 @@
                 <p>To find when there would be <m>8</m> oz of water left, we write and solve this equation:
                     <md>
                         <mrow>21-\frac{3}{5}m\amp=8</mrow>
-                        <mrow>\highlight{5\cdot{}}(21-\frac{3}{5}x)\amp=\highlight{5\cdot{}}8</mrow>
+                        <mrow>\multiplyleft{5}(21-\frac{3}{5}x)\amp=\multiplyleft{5}8</mrow>
                         <mrow>5\cdot21-5\cdot\frac{3}{5}x\amp=40</mrow>
                         <mrow>105-3m\amp=40</mrow>
-                        <mrow>105-3m\highlight{{}-105}\amp=40\highlight{{}-105}</mrow>
+                        <mrow>105-3m\subtractright{105}\amp=40\subtractright{105}</mrow>
                         <mrow>-3m\amp=-55</mrow>
                         <mrow>\frac{-3m}{-3}\amp=\frac{-55}{-3}</mrow>
                         <mrow>m\amp=\frac{55}{3}</mrow>
@@ -490,10 +490,10 @@
                 <p>
                     <md>
                         <mrow>\frac{3}{4}x-2\amp\gt\frac{4}{5}x</mrow>
-                        <mrow>\highlight{20\cdot{}}\left(\frac{3}{4}x-2\right)\amp\gt\highlight{20\cdot{}}\frac{4}{5}x</mrow>
+                        <mrow>\multiplyleft{20}\left(\frac{3}{4}x-2\right)\amp\gt\multiplyleft{20}\frac{4}{5}x</mrow>
                         <mrow>20\cdot\frac{3}{4}x-20\cdot2\amp\gt16x</mrow>
                         <mrow>15x-40\amp\gt16x</mrow>
-                        <mrow>15x-40\highlight{{}-15x}\amp\gt16x\highlight{{}-15x}</mrow>
+                        <mrow>15x-40\subtractright{15x}\amp\gt16x\subtractright{15x}</mrow>
                         <mrow>-40\amp\gt x</mrow>
                         <mrow>x\amp\lt-40</mrow>
                     </md>
@@ -512,11 +512,11 @@
                 <p>
                     <md>
                         <mrow>\frac{4}{7}-\frac{4}{3}y\amp\le\frac{2}{3}</mrow>
-                        <mrow>\highlight{21\cdot{}}\left(\frac{4}{7}-\frac{4}{3}y\right)\amp\le\highlight{21\cdot{}}\left(\frac{2}{3}\right)</mrow>
+                        <mrow>\multiplyleft{21}\left(\frac{4}{7}-\frac{4}{3}y\right)\amp\le\multiplyleft{21}\left(\frac{2}{3}\right)</mrow>
                         <mrow>21\left(\frac{4}{7}\right)-21\left(\frac{4}{3}y\right)\amp\le21\left(\frac{2}{3}\right)</mrow>
                         <mrow>12-28y\amp\le14</mrow>
                         <mrow>-28y\amp\le2</mrow>
-                        <mrow>\frac{-28y}{\highlight{{} -28}}\amp\ge\frac{2}{\highlight{{} -28}}</mrow>
+                        <mrow>\divideunder{-28y}{-28}\amp\ge\divideunder{2}{-28}</mrow>
                         <mrow>y\amp\ge-\frac{1}{14}</mrow>
                     </md>
                 </p>
@@ -536,7 +536,7 @@
                     <md>
                         <mrow>\frac{78+54+x}{3}\amp\ge70</mrow>
                         <mrow>\frac{132+x}{3}\amp\ge70</mrow>
-                        <mrow>\highlight{3\cdot{}}\frac{132+x}{3}\amp\ge\highlight{3\cdot{}}70</mrow>
+                        <mrow>\multiplyleft{3}\frac{132+x}{3}\amp\ge\multiplyleft{3}70</mrow>
                         <mrow>132+x\amp\ge210</mrow>
                         <mrow>x\amp\ge78</mrow>
                     </md>

--- a/src/section-solving-linear-equations-mixing-problems.mbx
+++ b/src/section-solving-linear-equations-mixing-problems.mbx
@@ -183,7 +183,7 @@
                     <md>
                         <mrow>8(h+0.5)\amp=24h</mrow>
                         <mrow>8h+4\amp=24h</mrow>
-                        <mrow>8h+4\highlight{{}-8h}\amp=24h\highlight{{}-8h}</mrow>
+                        <mrow>8h+4\subtractright{8h}\amp=24h\subtractright{8h}</mrow>
                         <mrow>4\amp=16h</mrow>
                         <mrow>\frac{4}{16}\amp=\frac{16h}{16}</mrow>
                         <mrow>0.25\amp=h</mrow>
@@ -246,7 +246,7 @@
                         <mrow>0.02x+0.05(8000-x)\amp=220</mrow>
                         <mrow>0.02x+400-0.05x\amp=220</mrow>
                         <mrow>-0.03x+400\amp=220</mrow>
-                        <mrow>-0.03x+400\highlight{{}-400}\amp=220\highlight{{}-400}</mrow>
+                        <mrow>-0.03x+400\subtractright{400}\amp=220\subtractright{400}</mrow>
                         <mrow>-0.03x\amp=-180</mrow>
                         <mrow>\frac{-0.03x}{-0.03}\amp=\frac{-180}{-0.03}</mrow>
                         <mrow>x\amp=6000</mrow>
@@ -310,7 +310,7 @@
                         <mrow>0.02x+(-400+0.04x)\amp=-190</mrow>
                         <mrow>0.02x-400+0.04x\amp=-190</mrow>
                         <mrow>0.06x-400\amp=-190</mrow>
-                        <mrow>0.06x-400\highlight{{}+400}\amp=-190\highlight{{}+400}</mrow>
+                        <mrow>0.06x-400\addright{400}\amp=-190\addright{400}</mrow>
                         <mrow>0.06x\amp=210</mrow>
                         <mrow>\frac{0.06x}{0.06}\amp=\frac{210}{0.06}</mrow>
                         <mrow>x\amp=3500</mrow>
@@ -390,9 +390,9 @@
                     <md>
                         <mrow>3.2+0.02x\amp=0.06(x+40)</mrow>
                         <mrow>3.2+0.02x\amp=0.06x+2.4</mrow>
-                        <mrow>3.2+0.02x\highlight{{}-0.02x}\amp=0.06x+2.4\highlight{{}-0.02x}</mrow>
+                        <mrow>3.2+0.02x\subtractright{0.02x}\amp=0.06x+2.4\subtractright{0.02x}</mrow>
                         <mrow>3.2\amp=0.04x+2.4</mrow>
-                        <mrow>3.2\highlight{{}-2.4}\amp=0.04x+2.4\highlight{{}-2.4}</mrow>
+                        <mrow>3.2\subtractright{2.4}\amp=0.04x+2.4\subtractright{2.4}</mrow>
                         <mrow>0.8\amp=0.04x</mrow>
                         <mrow>\frac{0.8}{0.04}\amp=\frac{0.04x}{0.04}</mrow>
                         <mrow>20\amp=x</mrow>
@@ -491,9 +491,9 @@
                     <md>
                         <mrow>360+8p\amp=9.2(p+30)</mrow>
                         <mrow>360+8p\amp=9.2p+276</mrow>
-                        <mrow>360+8p\highlight{{}-8p}\amp=9.2p+276\highlight{{}-8p}</mrow>
+                        <mrow>360+8p\subtractright{8p}\amp=9.2p+276\subtractright{8p}</mrow>
                         <mrow>360\amp=1.2p+276</mrow>
-                        <mrow>360\highlight{{}-276}\amp=1.2p+276\highlight{{}-276}</mrow>
+                        <mrow>360\subtractright{276}\amp=1.2p+276\subtractright{276}</mrow>
                         <mrow>84\amp=1.2p</mrow>
                         <mrow>\frac{84}{1.2}\amp=\frac{1.2p}{1.2}</mrow>
                         <mrow>70\amp=p</mrow>
@@ -583,7 +583,7 @@
 
                 <p>According to the table, the north campus had <m>100</m> LGBT students, and the south campus had <m>500p</m> LGBT students. Since the merged campus had <m>130</m> LGBT students, we can write and solve this equation:<md>
                     <mrow>100+500p\amp=130</mrow>
-                    <mrow>100+500p\highlight{{}-100}\amp=130\highlight{{}-100}</mrow>
+                    <mrow>100+500p\subtractright{100}\amp=130\subtractright{100}</mrow>
                     <mrow>500p\amp=30</mrow>
                     <mrow>\frac{500p}{500}\amp=\frac{30}{500}</mrow>
                     <mrow>p\amp=0.06</mrow>

--- a/src/section-solving-multistep-linear-equations-and-inequalities.mbx
+++ b/src/section-solving-multistep-linear-equations-and-inequalities.mbx
@@ -81,7 +81,7 @@
             <p>First, we need to separate the variable term, <m>15m</m>, in the equation. In other words, we need to remove <m>5</m> from the left side of the equal sign. We can do this by subtracting <m>5</m> from both sides of the equation. Once the variable term is separated, we can eliminate the coefficient and solve for <m>m</m>. The full process appears as:
                 <md>
                     <mrow>15m+5\amp=140</mrow>
-                    <mrow>15m+5\highlight{{}-5}\amp=140\highlight{{}-5}</mrow>
+                    <mrow>15m+5\subtractright{5}\amp=140\subtractright{5}</mrow>
                     <mrow>15m\amp=135</mrow>
                     <mrow>\frac{15m}{15}\amp=\frac{135}{15}</mrow>
                     <mrow>m\amp=9</mrow>
@@ -126,7 +126,7 @@
                 <p>To solve, we will first separate the variable terms and constant terms onto different sides of the equation. Then we will eliminate the variable term's coefficient:
                     <md>
                         <mrow>7-3y\amp=-8</mrow>
-                        <mrow>7-3y\highlight{{}-7}\amp=-8\highlight{{}-7}</mrow>
+                        <mrow>7-3y\subtractright{7}\amp=-8\subtractright{7}</mrow>
                         <mrow>-3y\amp=-15</mrow>
                         <mrow>\frac{-3y}{-3}\amp=\frac{-15}{-3}</mrow>
                         <mrow>y\amp=5</mrow>
@@ -166,9 +166,9 @@
             <p>Here is the full process:
                 <md>
                     <mrow>550m+2500\amp=250m+4600</mrow>
-                    <mrow>550m+2500\highlight{{}-2500}\amp=250m+4600\highlight{{}-2500}</mrow>
+                    <mrow>550m+2500\subtractright{2500}\amp=250m+4600\subtractright{2500}</mrow>
                     <mrow>550m\amp=250m+2100</mrow>
-                    <mrow>550m\highlight{{}-250m}\amp=250m+2100\highlight{{}-250m}</mrow>
+                    <mrow>550m\subtractright{250m}\amp=250m+2100\subtractright{250m}</mrow>
                     <mrow>300m\amp=2100</mrow>
                     <mrow>\frac{300m}{300}\amp=\frac{2100}{300}</mrow>
                     <mrow>m\amp=7</mrow>
@@ -205,9 +205,9 @@
                 <p>
                     <md>
                         <mrow>5-2x\amp=5x-9</mrow>
-                        <mrow>5-2x\highlight{{}-5}\amp=5m-9\highlight{{}-5}</mrow>
+                        <mrow>5-2x\subtractright{5}\amp=5m-9\subtractright{5}</mrow>
                         <mrow>-2x\amp=5x-14</mrow>
-                        <mrow>-2x\highlight{{}-5x}\amp=5x-14\highlight{{}-5x}</mrow>
+                        <mrow>-2x\subtractright{5x}\amp=5x-14\subtractright{5x}</mrow>
                         <mrow>-7x\amp=-14</mrow>
                         <mrow>\frac{-7x}{-7}\amp=\frac{-14}{-7}</mrow>
                         <mrow>x\amp=2</mrow>
@@ -217,9 +217,9 @@
                 <p>We could have moved variable terms to the right side of the equal sign, and number terms to the left side. We would have got the same solution, but we can avoid negative coefficient. Let's compare:
                     <md>
                         <mrow>5-2x\amp=5x-9</mrow>
-                        <mrow>5-2x\highlight{{}+9}\amp=5x-9\highlight{{}+9}</mrow>
+                        <mrow>5-2x\addright{9}\amp=5x-9\addright{9}</mrow>
                         <mrow>14-2x\amp=5x</mrow>
-                        <mrow>14-2x\highlight{{}+2x}\amp=5x\highlight{{}+2x}</mrow>
+                        <mrow>14-2x\addright{2x}\amp=5x\addright{2x}</mrow>
                         <mrow>14\amp=7x</mrow>
                         <mrow>\frac{14}{7}\amp=\frac{7x}{7}</mrow>
                         <mrow>2\amp=x</mrow>
@@ -229,7 +229,7 @@
                 <p>We could save a step by moving variable terms and number terms in one step:
                     <md>
                         <mrow>5-2x\amp=5x-9</mrow>
-                        <mrow>5-2x\highlight{{}+2x+9}\amp\phantom{=}5x-9\highlight{{}+2x+9}</mrow>
+                        <mrow>5-2x\addright{2x+9}\amp\phantom{=}5x-9\addright{2x+9}</mrow>
                         <mrow>14\amp=7x</mrow>
                         <mrow>\frac{14}{7}\amp=\frac{7x}{7}</mrow>
                         <mrow>2\amp=x</mrow>
@@ -273,9 +273,9 @@
                     <md>
                         <mrow>n-9+3n\amp=n-3n</mrow>
                         <mrow>4n-9\amp=-2n</mrow>
-                        <mrow>4n-9\highlight{{}-4n}\amp=-2n\highlight{{}-4n}</mrow>
+                        <mrow>4n-9\subtractright{4n}\amp=-2n\subtractright{4n}</mrow>
                         <mrow>-9\amp=-6n</mrow>
-                        <mrow>\frac{-9}{\highlight{-6}}\amp=\frac{-6n}{\highlight{-1}}</mrow>
+                        <mrow>\divideunder{-9}{-6}\amp=\divideunder{-6n}{-6}</mrow>
                         <mrow>n\amp=\frac{3}{2}</mrow>
                     </md>
                 </p>
@@ -321,7 +321,7 @@
                 <md>
                     <mrow>40\amp=2(4W-4)</mrow>
                     <mrow>40\amp=8W-8</mrow>
-                    <mrow>40\highlight{{}+8}\amp=8W-8\highlight{{}+8}</mrow>
+                    <mrow>40\addright{8}\amp=8W-8\addright{8}</mrow>
                     <mrow>48\amp=8W</mrow>
                     <mrow>6\amp=W</mrow>
                 </md>
@@ -370,9 +370,9 @@
                         <mrow>4-(3-a)\amp=-2-2(2a+1)</mrow>
                         <mrow>4-3+a\amp=-2-4a-2</mrow> %\amp\text{Parentheses were removed.}
                         <mrow>1+a\amp=-4-4a</mrow> %\amp\text{Like terms were combined.}
-                        <mrow>1+a\highlight{{}+4a}\amp=-4-4a\highlight{{}+4a}</mrow>
+                        <mrow>1+a\addright{4a}\amp=-4-4a\addright{4a}</mrow>
                         <mrow>1+5a\amp=-4</mrow>
-                        <mrow>1+5a\highlight{{}-1}\amp=-4\highlight{{}-1}</mrow>
+                        <mrow>1+5a\subtractright{1}\amp=-4\subtractright{1}</mrow>
                         <mrow>5a\amp=-5</mrow> %\amp\text{Variable terms and numbers terms were separated.}
                         <mrow>\frac{5a}{5}\amp=\frac{-5}{5}</mrow>
                         <mrow>a\amp=-1</mrow>
@@ -427,7 +427,7 @@
                 <p>
                     <md>
                         <mrow>-3t+5\amp\geq11</mrow>
-                        <mrow>-3t+5\highlight{{}-5}\amp\geq11\highlight{{}-5}</mrow>
+                        <mrow>-3t+5\subtractright{5}\amp\geq11\subtractright{5}</mrow>
                         <mrow>-3t\amp\geq6</mrow>
                         <mrow>\frac{-3t}{-3}\amp\leq\frac{6}{-3}</mrow>
                         <mrow>t\amp\leq-2</mrow>
@@ -468,7 +468,7 @@
                         <mrow>(6z+5)-(2z-3)\amp\lt-12</mrow>
                         <mrow>6z+5-2z+3\amp\lt-12</mrow>
                         <mrow>4z+8\amp\lt-12</mrow>
-                        <mrow>4z+8\highlight{{}-8}\amp\lt-12\highlight{{}-8}</mrow>
+                        <mrow>4z+8\subtractright{8}\amp\lt-12\subtractright{8}</mrow>
                         <mrow>4z\amp\lt-20</mrow>
                         <mrow>\frac{4z}{4}\amp\lt\frac{-20}{4}</mrow>
                         <mrow>z\amp\lt -5</mrow>
@@ -491,9 +491,9 @@
                         <mrow>-2-2(2x+1)\amp\gt4-(3-x)</mrow>
                         <mrow>-2-4x-2\amp\gt4-3+x</mrow>
                         <mrow>-4x-4\amp\gt x+1</mrow>
-                        <mrow>-4x-4\highlight{{}-x}\amp\gt x+1\highlight{{}-x}</mrow>
+                        <mrow>-4x-4\subtractright{x}\amp\gt x+1\subtractright{x}</mrow>
                         <mrow>-5x-4\amp\gt1</mrow>
-                        <mrow>-5x-4\highlight{{}+4}\amp\gt1\highlight{{}+4}</mrow>
+                        <mrow>-5x-4\addright{4}\amp\gt1\addright{4}</mrow>
                         <mrow>-5x\amp\gt5</mrow>
                         <mrow>\frac{-5x}{-5}\amp\lt\frac{5}{-5}</mrow>
                         <mrow>x\amp\lt-1</mrow>
@@ -516,7 +516,7 @@
             <p>The container is safe when the pressure is <m>21.7</m> atm or lower. We can write and solve this inequality:
                 <md>
                     <mrow>0.7m+4.2\amp\leq21.7</mrow>
-                    <mrow>0.7m+4.2\highlight{{}-4.2}\amp\leq21.7\highlight{{}-4.2}</mrow>
+                    <mrow>0.7m+4.2\subtractright{4.2}\amp\leq21.7\subtractright{4.2}</mrow>
                     <mrow>0.7m\amp\leq17.5</mrow>
                     <mrow>\frac{0.7m}{0.7}\amp\leq\frac{17.5}{0.7}</mrow>
                     <mrow>m\amp\leq25</mrow>

--- a/src/section-solving-one-step-equations-involving-percentages.mbx
+++ b/src/section-solving-one-step-equations-involving-percentages.mbx
@@ -19,351 +19,351 @@
     <title>Solving One-Step Equations Involving Percentages</title>
 
     <introduction>
-    	<p>With the skills we have learned regarding solving one-step linear equations, we can solve a variety of percent-related problems that are used in our everyday life. We will start this topic with a video lecture.</p>
+        <p>With the skills we have learned regarding solving one-step linear equations, we can solve a variety of percent-related problems that are used in our everyday life. We will start this topic with a video lecture.</p>
 
         <figure>
             <caption>Alternative Video Lesson</caption>
             <video youtube="LkTYkHbUiU4"/>
         </figure>
-	</introduction>
+    </introduction>
 
 
     <subsection>
-    	<title>Introduction</title>
+        <title>Introduction</title>
 
         <p>In many situations, the word <q>of</q> can be translated into a multiplication sign. For example:
-        	<md>
-        		<mrow>\text{One third }\amp\text{of thirty is ten.}</mrow>
-        		<mrow>\frac{1}{3}\amp\cdot30=10</mrow>
-        	</md>
+            <md>
+                <mrow>\text{One third }\amp\text{of thirty is ten.}</mrow>
+                <mrow>\frac{1}{3}\amp\cdot30=10</mrow>
+            </md>
 
         It's also helpful to note that when we translate a mathematical statement into one with symbols, the word <q>is</q> translates to an equal sign in our mathematical statement.
         </p>
 
         <p>Next, we will translate a sentence involving a percent into a mathematical equation. We all know <q><m>2</m> is <m>50\%</m> of <m>4</m>,</q> so we have:
-        	<md>
-        		<mrow>2 \text{ is }\amp 50\% \text{ of } 4</mrow>
-        		<mrow>2=\amp 0.5\cdot4</mrow>
-        	</md>
+            <md>
+                <mrow>2 \text{ is }\amp 50\% \text{ of } 4</mrow>
+                <mrow>2=\amp 0.5\cdot4</mrow>
+            </md>
         </p>
 
         <p>Those two lines above are a good example of the percentage formula, <m>A=PB</m>, where <m>A</m> represents an amount, <m>P</m> represents a percent, and <m>B</m> represents the base amount. The fact that <m>50\%=0.5</m> should remind us how to change a percentage into a number, and vice versa. We will look at a few examples.</p>
 
-		<example xml:id="example-translate-percent-statement-to-equation">
-			<statement>
-				<p>Translate each statement involving percents below into an equation. Define any variables used. (Solving these equations is an exercise). 
-					<ol>
-						<li><p>How much is <m>30\%</m> of <m>\$24.00</m>?</p></li>
-						<li><p><m>\$7.20</m> is what percent of <m>\$24.00</m>?</p></li>
-						<li><p><m>\$7.20</m> is <m>30\%</m> of how much money?</p></li>
-					</ol>
-				</p>
-			</statement>
-			<solution>
-				<p>We'll use the general equation <m>A=PB</m> to translate each statement.  
-					<ol>
-						<li><p>Let <m>x</m> be the unknown amount (in dollars). Translated into an equation, we have <m>x=0.3\cdot 24</m>.</p></li>
-						<li><p>Let <m>P</m> be the unknown percent. Translated into an equation, we have <m>7.2=P\cdot 24</m>.</p></li>
-						<li><p>Let <m>y</m> be the unknown amount (in dollars).Translated into an equation, we have <m>7.2=0.3y</m></p></li>
-					</ol>
-				</p>
-			</solution>
-		</example>
+        <example xml:id="example-translate-percent-statement-to-equation">
+            <statement>
+                <p>Translate each statement involving percents below into an equation. Define any variables used. (Solving these equations is an exercise). 
+                    <ol>
+                        <li><p>How much is <m>30\%</m> of <m>\$24.00</m>?</p></li>
+                        <li><p><m>\$7.20</m> is what percent of <m>\$24.00</m>?</p></li>
+                        <li><p><m>\$7.20</m> is <m>30\%</m> of how much money?</p></li>
+                    </ol>
+                </p>
+            </statement>
+            <solution>
+                <p>We'll use the general equation <m>A=PB</m> to translate each statement.  
+                    <ol>
+                        <li><p>Let <m>x</m> be the unknown amount (in dollars). Translated into an equation, we have <m>x=0.3\cdot 24</m>.</p></li>
+                        <li><p>Let <m>P</m> be the unknown percent. Translated into an equation, we have <m>7.2=P\cdot 24</m>.</p></li>
+                        <li><p>Let <m>y</m> be the unknown amount (in dollars).Translated into an equation, we have <m>7.2=0.3y</m></p></li>
+                    </ol>
+                </p>
+            </solution>
+        </example>
 
-		<exercise>
-			<statement>
-				<p>Solve each equation from <xref ref="example-translate-percent-statement-to-equation">Example</xref>.</p>
-			</statement>
-			<solution>
-				<p><ol>
-					<li><p><md>
-		        		<mrow>x\amp=0.3\cdot24</mrow>
-		        		<mrow>x\amp=7.2</mrow>
-		        	</md></p></li>
-					<li><p><md>
-		        		<mrow>7.2\amp=P\cdot24</mrow>
-		        		<mrow>\frac{7.2}{\highlight{{}24}}\amp=\frac{P}{\highlight{{}24}}</mrow>
-						<mrow>P\amp=30</mrow>
-		        	</md></p></li>
-					<li><p><md>
-	        			<mrow>7.2\amp=0.3\cdot y</mrow>
-		        		<mrow>\frac{7.2}{\highlight{{}0.3}}\amp=\frac{0.3y}{\highlight{{}0.3}}</mrow>
-		        		<mrow>24\amp=y</mrow>
-		        	</md></p></li>
-				</ol></p>
-			</solution>
-		</exercise>
+        <exercise>
+            <statement>
+                <p>Solve each equation from <xref ref="example-translate-percent-statement-to-equation">Example</xref>.</p>
+            </statement>
+            <solution>
+                <p><ol>
+                    <li><p><md>
+                        <mrow>x\amp=0.3\cdot24</mrow>
+                        <mrow>x\amp=7.2</mrow>
+                    </md></p></li>
+                    <li><p><md>
+                        <mrow>7.2\amp=P\cdot24</mrow>
+                        <mrow>\divideunder{7.2}{24}\amp=\divideunder{P}{24}</mrow>
+                        <mrow>P\amp=30</mrow>
+                    </md></p></li>
+                    <li><p><md>
+                        <mrow>7.2\amp=0.3\cdot y</mrow>
+                        <mrow>\divideunder{7.2}{0.3}\amp=\divideunder{0.3y}{0.3}</mrow>
+                        <mrow>24\amp=y</mrow>
+                    </md></p></li>
+                </ol></p>
+            </solution>
+        </exercise>
 
         <p>An important ability to do percent-related problems is to boil down a complicated word problem into the form of <q><m>2</m> is <m>50\%</m> of <m>4</m>.</q> Let's look at some further examples.</p>
 
-		<remark>
-			<p>When solving equations and inequalities out of context (in other words, problems that are <em>not</em> applications), it's important that we state the solution set. This communicates the set of all solution(s) to that equation or inequality. When solving an equation or inequality that is an application problem though, it makes more sense to instead summarize our result with a sentence. This allows us to communicate the full result, including appropriate units.</p>
-		</remark>
-	</subsection>
+        <remark>
+            <p>When solving equations and inequalities out of context (in other words, problems that are <em>not</em> applications), it's important that we state the solution set. This communicates the set of all solution(s) to that equation or inequality. When solving an equation or inequality that is an application problem though, it makes more sense to instead summarize our result with a sentence. This allows us to communicate the full result, including appropriate units.</p>
+        </remark>
+    </subsection>
 
-	<subsection>
-    	<title>Modeling and Solving Percent Equations</title>
+    <subsection>
+        <title>Modeling and Solving Percent Equations</title>
 
         <example>
-        	<statement>
-        		<p>As of Fall 2016 term, Portland Community College had <m>89,900</m> enrolled students. Among them, <m>6\%</m> were African Americans. How many African American students were enrolled at PCC as of Fall 2016 term?</p>
-			</statement>
-			<solution>
-        		<p>After reading this word problem, we can translate the problem into <q>what is <m>6\%</m> of <m>89900</m>?</q> Assume <m>x</m> African American students were enrolled at PCC as of Fall 2016 term, we will write and solve the equation:
-	        		<md>
-	        			<mrow>x\amp=0.06\cdot89900</mrow>
-	        			<mrow>x\amp=5394</mrow>
-	        		</md>
-	        	As of Fall 2016 term, <m>5,394</m> African American students were enrolled at PCC.</p>
-        	</solution>
+            <statement>
+                <p>As of Fall 2016 term, Portland Community College had <m>89,900</m> enrolled students. Among them, <m>6\%</m> were African Americans. How many African American students were enrolled at PCC as of Fall 2016 term?</p>
+            </statement>
+            <solution>
+                <p>After reading this word problem, we can translate the problem into <q>what is <m>6\%</m> of <m>89900</m>?</q> Assume <m>x</m> African American students were enrolled at PCC as of Fall 2016 term, we will write and solve the equation:
+                    <md>
+                        <mrow>x\amp=0.06\cdot89900</mrow>
+                        <mrow>x\amp=5394</mrow>
+                    </md>
+                As of Fall 2016 term, <m>5,394</m> African American students were enrolled at PCC.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-        		<p>Kim just received her monthly paycheck. Her total earning was <m>\$2,346.19</m>, and her total tax and decution was <m>\$350.21</m>. The rest went into her checking account. What percent of her total earning went into her checking account? Round your answer to two decimal places.</p>
-			</statement>
-			<solution>
-	        	<p>Be careful that <m>\$350.21</m> did <em>not</em> go into her checking account. We need to do a subtraction to find that amount:<me>2346.19-350.21=1995.98</me></p>
+            <statement>
+                <p>Kim just received her monthly paycheck. Her total earning was <m>\$2,346.19</m>, and her total tax and decution was <m>\$350.21</m>. The rest went into her checking account. What percent of her total earning went into her checking account? Round your answer to two decimal places.</p>
+            </statement>
+            <solution>
+                <p>Be careful that <m>\$350.21</m> did <em>not</em> go into her checking account. We need to do a subtraction to find that amount:<me>2346.19-350.21=1995.98</me></p>
 
-	        	<p>Now, we can translate the problem into <q><m>1995.98</m> is what percent of <m>2346.19</m>?</q> Assume <m>x</m> (as a percentage) of her total earning went into her checking account, we will write and solve the equation:
-			        <md>
-		        		<mrow>1995.98\amp=x\cdot2346.19</mrow>
-		        		<mrow>1995.98\amp=2346.19x</mrow>
-		        		<mrow>\frac{1995.98}{2346.19}\amp=\frac{2346.19x}{2346.19}</mrow>
-		        		<mrow>0.85073...\amp=x</mrow>
-		        		<mrow>x\amp\approx85.07\%</mrow>
-		        	</md>
-				Approximately <m>85.07\%</m> of her total earning went into her checking account.</p>
-			</solution>
+                <p>Now, we can translate the problem into <q><m>1995.98</m> is what percent of <m>2346.19</m>?</q> Assume <m>x</m> (as a percentage) of her total earning went into her checking account, we will write and solve the equation:
+                    <md>
+                        <mrow>1995.98\amp=x\cdot2346.19</mrow>
+                        <mrow>1995.98\amp=2346.19x</mrow>
+                        <mrow>\frac{1995.98}{2346.19}\amp=\frac{2346.19x}{2346.19}</mrow>
+                        <mrow>0.85073...\amp=x</mrow>
+                        <mrow>x\amp\approx85.07\%</mrow>
+                    </md>
+                Approximately <m>85.07\%</m> of her total earning went into her checking account.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-        		<p>Kandace sells cars for a living, and earns <m>28\%</m> of the dealer's sales profit as commission. In a certain month, she plans to earn <m>\$2,200</m> in commission. How much sales profit does she need to make for the dealer?</p>
-			</statement>
-			<solution>
-	        	<p>Be careful that we cannot calculate <m>28\%</m> of <m>\$2,200</m>, because <m>\$2,200</m> is not the dealer's sales profit. If we made a mistake and did <m>0.28\cdot2200=616</m>, it would not make sense if Kandace earned <m>\$2,200</m> in commission for making only <m>\$616</m> of sales profit for the dealer.</p>
+            <statement>
+                <p>Kandace sells cars for a living, and earns <m>28\%</m> of the dealer's sales profit as commission. In a certain month, she plans to earn <m>\$2,200</m> in commission. How much sales profit does she need to make for the dealer?</p>
+            </statement>
+            <solution>
+                <p>Be careful that we cannot calculate <m>28\%</m> of <m>\$2,200</m>, because <m>\$2,200</m> is not the dealer's sales profit. If we made a mistake and did <m>0.28\cdot2200=616</m>, it would not make sense if Kandace earned <m>\$2,200</m> in commission for making only <m>\$616</m> of sales profit for the dealer.</p>
 
-	        	<p>We can translate the problem into <q><m>2,200</m> is <m>28\%</m> of what?</q> Assume she needs to make <m>x</m> dollars of sales profit for the dealer, we will write and solve the equation:
-		        	<md>
-		        		<mrow>2200\amp=0.28\cdot x</mrow>
-		        		<mrow>\frac{2200}{0.28}\amp=\frac{0.28x}{0.28}</mrow>
-		        		<mrow>7857.142...\amp=x</mrow>
-		        		<mrow>x\amp\approx7857.14</mrow>
-		        	</md>
-	        	</p>
+                <p>We can translate the problem into <q><m>2,200</m> is <m>28\%</m> of what?</q> Assume she needs to make <m>x</m> dollars of sales profit for the dealer, we will write and solve the equation:
+                    <md>
+                        <mrow>2200\amp=0.28\cdot x</mrow>
+                        <mrow>\frac{2200}{0.28}\amp=\frac{0.28x}{0.28}</mrow>
+                        <mrow>7857.142...\amp=x</mrow>
+                        <mrow>x\amp\approx7857.14</mrow>
+                    </md>
+                </p>
 
-	        	<p>To earn <m>\$2,200</m> in commission, Kandace needs to make approximately <m>\$7857.14</m> of sales profit for the dealer.</p>
-			</solution>
+                <p>To earn <m>\$2,200</m> in commission, Kandace needs to make approximately <m>\$7857.14</m> of sales profit for the dealer.</p>
+            </solution>
         </example>
 
         <p>In the following price increase/decrease problems, the key is to identify the original price, which represents <m>100\%</m>. Let's look at a few examples.</p>
 
         <example>
-        	<statement>
-        		<p>A shirt is on sale with <m>15\%</m> off. The current price is <m>\$51.00</m>. What was the original price?</p>
-			</statement>
-			<solution>
-	        	<p>If the shirt was <m>15\%</m> off, its current price must be <m>100\%-15\%=85\%</m> of its original price. We can translate this problem into <q><m>51</m> is <m>85\%</m> of what?</q> Assume the shirt's original price was <m>x</m> dollars, we will write and solve the equation:
-	        		<md>
-		        		<mrow>51\amp=0.85\cdot x</mrow>
-		        		<mrow>\frac{51}{0.85}\amp=\frac{0.85x}{0.85}</mrow>
-		        		<mrow>60\amp=x</mrow>
-		        	</md>
-		        </p>
+            <statement>
+                <p>A shirt is on sale with <m>15\%</m> off. The current price is <m>\$51.00</m>. What was the original price?</p>
+            </statement>
+            <solution>
+                <p>If the shirt was <m>15\%</m> off, its current price must be <m>100\%-15\%=85\%</m> of its original price. We can translate this problem into <q><m>51</m> is <m>85\%</m> of what?</q> Assume the shirt's original price was <m>x</m> dollars, we will write and solve the equation:
+                    <md>
+                        <mrow>51\amp=0.85\cdot x</mrow>
+                        <mrow>\frac{51}{0.85}\amp=\frac{0.85x}{0.85}</mrow>
+                        <mrow>60\amp=x</mrow>
+                    </md>
+                </p>
 
-        		<p>The shirt's original price was <m>\$60.00</m>.</p>
-        	</solution>
+                <p>The shirt's original price was <m>\$60.00</m>.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-	        	<p>A shirt's price increased from <m>\$40.00</m> to <m>\$48.00</m>. What was the percent of increase?</p>
-			</statement>
-			<solution>
-	        	<p>The increase was <m>48-40=8</m> dollars. We need to find <q><m>8</m> is what percent of <m>40</m>?</q> Note that the original price, <m>\$40.00</m>, represents <m>100\%</m>. Assume the price increased by <m>x</m> (as a percent), we will write and solve the equation:
-	        		<md>
-		        		<mrow>8\amp=x\cdot40</mrow>
-		        		<mrow>8\amp=40x</mrow>
-		        		<mrow>\frac{8}{40}\amp=\frac{40x}{40}</mrow>
-		        		<mrow>0.2\amp=x</mrow>
-		        		<mrow>x\amp=20\%</mrow>
-		        	</md>
-	        	</p>
+            <statement>
+                <p>A shirt's price increased from <m>\$40.00</m> to <m>\$48.00</m>. What was the percent of increase?</p>
+            </statement>
+            <solution>
+                <p>The increase was <m>48-40=8</m> dollars. We need to find <q><m>8</m> is what percent of <m>40</m>?</q> Note that the original price, <m>\$40.00</m>, represents <m>100\%</m>. Assume the price increased by <m>x</m> (as a percent), we will write and solve the equation:
+                    <md>
+                        <mrow>8\amp=x\cdot40</mrow>
+                        <mrow>8\amp=40x</mrow>
+                        <mrow>\frac{8}{40}\amp=\frac{40x}{40}</mrow>
+                        <mrow>0.2\amp=x</mrow>
+                        <mrow>x\amp=20\%</mrow>
+                    </md>
+                </p>
 
-        		<p>The percent of increase in the shirt's price was <m>20\%</m>.</p>
-        	</solution>
+                <p>The percent of increase in the shirt's price was <m>20\%</m>.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-	        	<p>A shirt's original price was <m>\$40.00</m>. After a <m>35\%</m> price increase, what's the new price?</p>
-			</statement>
-			<solution>
-	        	<p>After a <m>35\%</m> increase, the new price would be <m>100\%+35\%=135\%</m> of its original price. We can translate this problem into <q>what is <m>135\%</m> of <m>40</m></q>. Assume the new price is <m>x</m> dollars, we will write and solve the equation:
-	        	<md>
-	        		<mrow>x\amp=1.35\cdot40</mrow>
-	        		<mrow>x\amp=54</mrow>
-	        	</md>
-	        	</p>
-			
-	        	<p>The shirt's new price is <m>\$54.00</m>.</p>
-	        </solution>
+            <statement>
+                <p>A shirt's original price was <m>\$40.00</m>. After a <m>35\%</m> price increase, what's the new price?</p>
+            </statement>
+            <solution>
+                <p>After a <m>35\%</m> increase, the new price would be <m>100\%+35\%=135\%</m> of its original price. We can translate this problem into <q>what is <m>135\%</m> of <m>40</m></q>. Assume the new price is <m>x</m> dollars, we will write and solve the equation:
+                <md>
+                    <mrow>x\amp=1.35\cdot40</mrow>
+                    <mrow>x\amp=54</mrow>
+                </md>
+                </p>
+            
+                <p>The shirt's new price is <m>\$54.00</m>.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-	        	<p>A shirt's original price was <m>\$40.00</m>. After a <m>35\%</m> price increase and a <m>35\%</m> price decrease, what's the new price?</p>
-			</statement>
-			<solution>
-	        	<p>From the last example, we know the shirt's new price after a <m>35\%</m> increase was <m>\$54.00</m>. Next, the price decreased by <m>35\%</m> of its <em>new</em> price, <m>\$54.00</m>. In other words, we must break this problem into two problems. The price increased in the first problem, and the original price was <m>\$40.00</m>; the price decreased in the second problem, and the original price was <m>\$54.00</m>.</p>
+            <statement>
+                <p>A shirt's original price was <m>\$40.00</m>. After a <m>35\%</m> price increase and a <m>35\%</m> price decrease, what's the new price?</p>
+            </statement>
+            <solution>
+                <p>From the last example, we know the shirt's new price after a <m>35\%</m> increase was <m>\$54.00</m>. Next, the price decreased by <m>35\%</m> of its <em>new</em> price, <m>\$54.00</m>. In other words, we must break this problem into two problems. The price increased in the first problem, and the original price was <m>\$40.00</m>; the price decreased in the second problem, and the original price was <m>\$54.00</m>.</p>
 
-	        	<p>After a <m>35\%</m> price decrease, the new price will be <m>100\%-35\%=65\%</m> of the original price. We can translate the second problem into <q>what is <m>65\%</m> of <m>54</m></q>. Assume the new price will be <m>x</m> dollars, we will write and solve the equation:<md>
-	        		<mrow>x\amp=0.65\cdot54</mrow>
-	        		<mrow>x\amp=35.1</mrow>
-	        	</md></p>
+                <p>After a <m>35\%</m> price decrease, the new price will be <m>100\%-35\%=65\%</m> of the original price. We can translate the second problem into <q>what is <m>65\%</m> of <m>54</m></q>. Assume the new price will be <m>x</m> dollars, we will write and solve the equation:<md>
+                    <mrow>x\amp=0.65\cdot54</mrow>
+                    <mrow>x\amp=35.1</mrow>
+                </md></p>
 
-	        	<p>The new price will be <m>\$35.10</m>. The decrease was greater than the increase, because the increase was <m>35\%</m> of <m>\$40.00</m>, but the decrease was <m>35\%</m> of <m>\$54.00</m>, a bigger amount.</p>
-	        </solution>
+                <p>The new price will be <m>\$35.10</m>. The decrease was greater than the increase, because the increase was <m>35\%</m> of <m>\$40.00</m>, but the decrease was <m>35\%</m> of <m>\$54.00</m>, a bigger amount.</p>
+            </solution>
         </example>
 
     </subsection>
 
     <exercises>
-    	<exercisegroup>
-    		<introduction><p>Basic Percentage Problems</p></introduction>
-			<exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_30.pg" seed="1"/>
-	        </exercise>
-    	</exercisegroup>
+        <exercisegroup>
+            <introduction><p>Basic Percentage Problems</p></introduction>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType1_30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType2_50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentOfNumberType3_30.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
 
-		<exercisegroup>
-    		<introduction><p>Percentage Application Problems</p></introduction>
-			<exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_80.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_90.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_100.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_120.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_120.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_60.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_80.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_110.pg" seed="1"/>
-	        </exercise>
-	    </exercisegroup>
+        <exercisegroup>
+            <introduction><p>Percentage Application Problems</p></introduction>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_80.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_90.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_100.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType1_120.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType2_120.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_60.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_80.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentApplicationType3_110.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
 
-		<exercisegroup>
-    		<introduction><p>Percent of Increase/Decrease Problems</p></introduction>
-			<exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease95.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease110.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease130.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease150.pg" seed="1"/>
-	        </exercise>
-	    </exercisegroup>
+        <exercisegroup>
+            <introduction><p>Percent of Increase/Decrease Problems</p></introduction>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease95.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease110.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease130.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicMath/Percent/MTH20PercentIncreaseDecrease150.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
 
-		<exercisegroup>
-    		<introduction><p>Geometry Application Problems</p></introduction>
-			<exercise>
-	            <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea60.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/CylinderVolume30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/RectanglePerimeterArea30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/RectangularPrismVolume30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/Geometry/TrianglePerimeterArea40.pg" seed="1"/>
-	        </exercise>
-	    </exercisegroup>
+        <exercisegroup>
+            <introduction><p>Geometry Application Problems</p></introduction>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/CircleCircumferenceArea60.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/CylinderVolume30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/RectanglePerimeterArea30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/RectangularPrismVolume30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/Geometry/TrianglePerimeterArea40.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
     </exercises>
 </section>

--- a/src/section-solving-one-step-equations.mbx
+++ b/src/section-solving-one-step-equations.mbx
@@ -19,7 +19,7 @@
     <title>Solving One-Step Equations</title>
 
     <introduction>
-    	<p>We have learned how to check whether a number is a solution of an equation or inequality. In this section, we will learn how to solve basic equations and inequalities. We will start with a video lecture.</p>
+        <p>We have learned how to check whether a number is a solution of an equation or inequality. In this section, we will learn how to solve basic equations and inequalities. We will start with a video lecture.</p>
 
         <figure>
             <caption>Alternative Video Lesson</caption>
@@ -28,551 +28,551 @@
     </introduction>
 
     <subsection>
-    	<title>Introduction</title>
+        <title>Introduction</title>
 
-    	<subsubsection>
-    		<title>Opposite Operation</title>
+        <subsubsection>
+            <title>Opposite Operation</title>
 
-	    	<p>We will start with a riddle: If a number plus <m>2</m> is <m>6</m>, what is the number?</p>
+            <p>We will start with a riddle: If a number plus <m>2</m> is <m>6</m>, what is the number?</p>
 
-	    	<p>One way to solve this riddle is to do the opposite operation. If a number plus <m>2</m> is <m>6</m>, we can subtract <m>2</m> from <m>6</m>, and the unknown number is <m>6-2=4</m>.</p>
+            <p>One way to solve this riddle is to do the opposite operation. If a number plus <m>2</m> is <m>6</m>, we can subtract <m>2</m> from <m>6</m>, and the unknown number is <m>6-2=4</m>.</p>
 
-	    	<p>Let's try this strategy with another riddle: If a number minus <m>2</m> is <m>6</m>, what is the number? This time, we add <m>2</m> to <m>6</m>, and the unknown number is <m>6+2=8</m>.</p>
+            <p>Let's try this strategy with another riddle: If a number minus <m>2</m> is <m>6</m>, what is the number? This time, we add <m>2</m> to <m>6</m>, and the unknown number is <m>6+2=8</m>.</p>
 
-	    	<p>Does this strategy work with multiplication and division? Let's look at another riddle: If a number times <m>2</m> is <m>6</m>, what is the number? This time, we divide <m>6</m> with <m>2</m>, and the unknown number is <m>6\div2=3</m>.</p>
+            <p>Does this strategy work with multiplication and division? Let's look at another riddle: If a number times <m>2</m> is <m>6</m>, what is the number? This time, we divide <m>6</m> with <m>2</m>, and the unknown number is <m>6\div2=3</m>.</p>
 
-	    	<p>If a number divided by <m>2</m> equals <m>6</m>, what is the number? This time, we multiply <m>6</m> with <m>2</m>, and the unknown number is <m>6\cdot2=12</m>.</p>
+            <p>If a number divided by <m>2</m> equals <m>6</m>, what is the number? This time, we multiply <m>6</m> with <m>2</m>, and the unknown number is <m>6\cdot2=12</m>.</p>
 
-	    	<p>We have learned an important strategy to solve an equation<mdash/>applying the opposite operation. The following example shows how to solve the first riddle with this strategy (assuming the unknown number is the variable <m>x</m>):
-	    		<md>
-		    		<mrow>x+2\amp=6</mrow>
-		    		<mrow>x\amp=6-2</mrow>
-		    		<mrow>x\amp=4</mrow>
-	    		</md>
-	    	</p>
-    	</subsubsection>
+            <p>We have learned an important strategy to solve an equation<mdash/>applying the opposite operation. The following example shows how to solve the first riddle with this strategy (assuming the unknown number is the variable <m>x</m>):
+                <md>
+                    <mrow>x+2\amp=6</mrow>
+                    <mrow>x\amp=6-2</mrow>
+                    <mrow>x\amp=4</mrow>
+                </md>
+            </p>
+        </subsubsection>
 
-    	<subsubsection>
-    		<title>Balancing Equations Like a Scale</title>
+        <subsubsection>
+            <title>Balancing Equations Like a Scale</title>
 
-    		<p>We will solve the first riddle with a different strategy: If a number plus <m>2</m> is <m>6</m>, what is the number?</p>
+            <p>We will solve the first riddle with a different strategy: If a number plus <m>2</m> is <m>6</m>, what is the number?</p>
 
-    		<p>Assume the unknown number is <m>x</m>, and we can write the equation <me>x+2=6</me> The equal sign is like the middle part of a balanced scale. The left side has <m>2</m> one-pound objects and a block with unknown weight <m>(x \text{ lb})</m>. The right side has <m>6</m> one-pound objects. The following figure shows the scale:</p>
+            <p>Assume the unknown number is <m>x</m>, and we can write the equation <me>x+2=6</me> The equal sign is like the middle part of a balanced scale. The left side has <m>2</m> one-pound objects and a block with unknown weight <m>(x \text{ lb})</m>. The right side has <m>6</m> one-pound objects. The following figure shows the scale:</p>
 
-	        <figure>
-	            <caption>Scale Model to Represent <m>x+2=6</m></caption>
-	            <image width="70%">
-	                <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-							\draw (0,1) -- (10,1);
-							\fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
-							\draw (0,1) rectangle (1,2);
-							\draw (0.5,1.5) node {$x$ lb};
-							\draw (0,2) rectangle (1,3);
-							\draw (0.5,2.5) node {$1$ lb};
-							\draw (0,3) rectangle (1,4);
-							\draw (0.5,3.5) node {$1$ lb};
-							\foreach \x in {1,2,...,6}
-								\draw (9,\x) rectangle (10,\x+1);
-							\foreach \x in {1.5,2.5,...,6.5}
-								\draw (9.5,\x) node {$1$ lb};
-	                    \end{tikzpicture}]]>
-	                </latex-image-code>
-	            </image>
-	        </figure>
+            <figure>
+                <caption>Scale Model to Represent <m>x+2=6</m></caption>
+                <image width="70%">
+                    <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \draw (0,1) -- (10,1);
+                            \fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
+                            \draw (0,1) rectangle (1,2);
+                            \draw (0.5,1.5) node {$x$ lb};
+                            \draw (0,2) rectangle (1,3);
+                            \draw (0.5,2.5) node {$1$ lb};
+                            \draw (0,3) rectangle (1,4);
+                            \draw (0.5,3.5) node {$1$ lb};
+                            \foreach \x in {1,2,...,6}
+                                \draw (9,\x) rectangle (10,\x+1);
+                            \foreach \x in {1.5,2.5,...,6.5}
+                                \draw (9.5,\x) node {$1$ lb};
+                        \end{tikzpicture}]]>
+                    </latex-image-code>
+                </image>
+            </figure>
 
-	        <p>To find the weight of the unknown block, we can take away <m>2</m> one-pound blocks from <em>both</em> sides of the scale (to keep the scale balanced). The following figure shows the solution.</p>
+            <p>To find the weight of the unknown block, we can take away <m>2</m> one-pound blocks from <em>both</em> sides of the scale (to keep the scale balanced). The following figure shows the solution.</p>
 
-	        <figure>
-	            <caption>Scale Model to Represent <m>x=4</m></caption>
-	            <image width="70%">
-	                <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-							\draw (0,1) -- (10,1);
-							\fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
-							\draw (0,1) rectangle (1,2);
-							\draw (0.5,1.5) node {$x$ lb};
-							\foreach \x in {1,2,...,4}
-								\draw (9,\x) rectangle (10,\x+1);
-							\foreach \x in {1.5,2.5,...,4.5}
-								\draw (9.5,\x) node {$1$ lb};
-	                    \end{tikzpicture}]]>
-	                </latex-image-code>
-	            </image>
-	        </figure>
+            <figure>
+                <caption>Scale Model to Represent <m>x=4</m></caption>
+                <image width="70%">
+                    <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \draw (0,1) -- (10,1);
+                            \fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
+                            \draw (0,1) rectangle (1,2);
+                            \draw (0.5,1.5) node {$x$ lb};
+                            \foreach \x in {1,2,...,4}
+                                \draw (9,\x) rectangle (10,\x+1);
+                            \foreach \x in {1.5,2.5,...,4.5}
+                                \draw (9.5,\x) node {$1$ lb};
+                        \end{tikzpicture}]]>
+                    </latex-image-code>
+                </image>
+            </figure>
 
-	        <p>An equation is like a balanced scale as the two sides of the equation are equal. In the same way that we can take away <m>2</m> lb from <em>both</em> sides of a balanced scale, we can subtract <m>2</m> on <em>both</em> sides of the equal sign. Using algebra, we solve the equation <m>x+2=6</m> in the following manner:</p>
+            <p>An equation is like a balanced scale as the two sides of the equation are equal. In the same way that we can take away <m>2</m> lb from <em>both</em> sides of a balanced scale, we can subtract <m>2</m> on <em>both</em> sides of the equal sign. Using algebra, we solve the equation <m>x+2=6</m> in the following manner:</p>
 
-	        	<p><md>
-	        		<mrow>x+2\amp=6</mrow>
-	        		<mrow>x+2\highlight{{}-2}\amp=6\highlight{{}-2}</mrow>
-	        		<mrow>x\amp=4</mrow>
-	        	</md></p>
-
-
-	        <p>It's important to note that each line shows what is called an <term>equivalent equation</term>. In other words, each equation shown is algebraically equivalent to the one above it and the one below it and will have exactly the same solution(s). The final equivalent equation <m>x=4</m> tells us that the <term>solution</term> to the equation is <m>4</m>. The <term>solution set</term> to this equation is the set that lists every solution to the equation. For this example, the solution set is <m>\{4\}</m>.</p>
-
-	        <p>We have learned we can add/subtract the same number on both sides of the equal sign, just like we can add/remove the same amount of weight on a balanced scale. Can we multiply/divide the same number on both sides of the equal sign?</p>
-
-	        <p>Let's look at the third riddle again: If a number times <m>2</m> is <m>6</m>, what is the number? We will use a scale to model this riddle:</p>
-
-	        <figure>
-	            <caption>Scale Model to Represent <m>2x=6</m></caption>
-	            <image width="70%">
-	                <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-							\draw (0,1) -- (10,1);
-							\fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
-							\draw (0,1) rectangle (1,2);
-							\draw (0.5,1.5) node {$x$ lb};
-							\draw (0,2) rectangle (1,3);
-							\draw (0.5,2.5) node {$x$ lb};
-							\foreach \x in {1,2,...,6}
-								\draw (9,\x) rectangle (10,\x+1);
-							\foreach \x in {1.5,2.5,...,6.5}
-								\draw (9.5,\x) node {$1$ lb};
-	                    \end{tikzpicture}]]>
-	                </latex-image-code>
-	            </image>
-	        </figure>
-
-	        <p>Currently, the scale is balanced. If we remove half of the weight on both sides, the scale should still be balanced:</p>
-
-	        <figure>
-	            <caption>Scale Model to Represent <m>x=3</m></caption>
-	            <image width="70%">
-	                <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-							\draw (0,1) -- (10,1);
-							\fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
-							\draw (0,1) rectangle (1,2);
-							\draw (0.5,1.5) node {$x$ lb};
-							\foreach \x in {1,2,...,3}
-								\draw (9,\x) rectangle (10,\x+1);
-							\foreach \x in {1.5,2.5,...,3.5}
-								\draw (9.5,\x) node {$1$ lb};
-	                    \end{tikzpicture}]]>
-	                </latex-image-code>
-	            </image>
-	        </figure>
-
-	        <p>We can see from the above scale that <m>x=3</m> is obviously correct. Removing half of the weight on both sides of the scale is like dividing both sides of an equation by <m>2</m>:
-	        	<md>
-		        	<mrow>2x\amp=6</mrow>
-		        	<mrow>\frac{2x}{\highlight{{}2}}\amp=\frac{6}{\highlight{{}2}}</mrow>
-		        	<mrow>x\amp=3</mrow>
-	        	</md>
-			The equivalent equation in this example is <m>x=3</m>, which tells us that the solution to the equation is <m>3</m> and the solution set is <m>\{3\}</m>.
-	        </p>
-
-	        <remark><p>Note that when we divide each side of an equation by a number, we use the fraction line in place of the division symbol. By <m>\frac{6}{2}=6\div2</m>, we can see the fraction line and division symbol have the same function. The division symbol is rarely used in later math courses.</p></remark>
-
-	        <p>Similarly, we could multiply both sides of an equation by <m>2</m>, just like we can keep a scale balanced if we double the weight on both sides. We will summarize these properties.</p>
-
-		    <fact xml:id="fact-properties-of-equivalent-equations">
-	            <title>Properties of Equivalent Equations</title>
-	            <index><main>Properties of Equivalent Equations</main></index>
-	            <statement>
-	                <p>If there is an equation <m>a=b</m>, we can do the following obtain an equivalent equation:
-	                	<ul>
-		                	<li><p>add the same number to each side: <m>a+c=b+c</m></p></li>
-							<li><p>subtract the same number from each side: <m>a-c=b-c</m></p></li>
-							<li><p>multiply each side of the equation by the same number: <m>ac=bc</m></p></li>
-							<li><p>divide each side of the equation by the same non-zero number: <m>\frac{a}{c}=\frac{b}{c}</m></p></li>
-						</ul>
-					</p>
-	            </statement>
-	        </fact>
-    	</subsubsection>
-	</subsection>
+                <p><md>
+                    <mrow>x+2\amp=6</mrow>
+                    <mrow>x+2\subtractright{2}\amp=6\subtractright{2}</mrow>
+                    <mrow>x\amp=4</mrow>
+                </md></p>
 
 
-	<subsection>
-		<title>Solving One-Step Equations and Stating Solution Sets</title>
+            <p>It's important to note that each line shows what is called an <term>equivalent equation</term>. In other words, each equation shown is algebraically equivalent to the one above it and the one below it and will have exactly the same solution(s). The final equivalent equation <m>x=4</m> tells us that the <term>solution</term> to the equation is <m>4</m>. The <term>solution set</term> to this equation is the set that lists every solution to the equation. For this example, the solution set is <m>\{4\}</m>.</p>
 
-	   	<p>Notice that when we solve an equation, the final equation looks like <m>x=3</m>, where the variable <m>x</m> is separated from other numbers and stands alone on one side of the equal sign. The goal of solving any equation is to <em>isolate the variable</em> in this same manner.</p>
+            <p>We have learned we can add/subtract the same number on both sides of the equal sign, just like we can add/remove the same amount of weight on a balanced scale. Can we multiply/divide the same number on both sides of the equal sign?</p>
 
-	   	<p>Putting together both strategies (applying the opposite operation and balancing equations like a scale) that we just explored, we will summarize how to solve a one-step linear equation.</p>
+            <p>Let's look at the third riddle again: If a number times <m>2</m> is <m>6</m>, what is the number? We will use a scale to model this riddle:</p>
 
-	    <list xml:id="list-solve-one-step-equation-strategy">
-	        <title>Steps to Solving Simple (One-Step) Linear Equations</title>
-	        <dl>
-	            <li><title>Apply</title><p>Apply the opposite operation to both sides of the equation.</p></li>
-	            <li><title>Check</title><p>Check the solution.</p></li>
-	            <li><title>Summarize</title><p>State the solution set or (in the case of application problems) summarize the result using a complsentence and appropriate units.</p></li>
-	        </dl>
-	    </list>
+            <figure>
+                <caption>Scale Model to Represent <m>2x=6</m></caption>
+                <image width="70%">
+                    <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \draw (0,1) -- (10,1);
+                            \fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
+                            \draw (0,1) rectangle (1,2);
+                            \draw (0.5,1.5) node {$x$ lb};
+                            \draw (0,2) rectangle (1,3);
+                            \draw (0.5,2.5) node {$x$ lb};
+                            \foreach \x in {1,2,...,6}
+                                \draw (9,\x) rectangle (10,\x+1);
+                            \foreach \x in {1.5,2.5,...,6.5}
+                                \draw (9.5,\x) node {$1$ lb};
+                        \end{tikzpicture}]]>
+                    </latex-image-code>
+                </image>
+            </figure>
+
+            <p>Currently, the scale is balanced. If we remove half of the weight on both sides, the scale should still be balanced:</p>
+
+            <figure>
+                <caption>Scale Model to Represent <m>x=3</m></caption>
+                <image width="70%">
+                    <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \draw (0,1) -- (10,1);
+                            \fill[black] (4.5,0) -- (5.5,0) -- (5,1) -- cycle;
+                            \draw (0,1) rectangle (1,2);
+                            \draw (0.5,1.5) node {$x$ lb};
+                            \foreach \x in {1,2,...,3}
+                                \draw (9,\x) rectangle (10,\x+1);
+                            \foreach \x in {1.5,2.5,...,3.5}
+                                \draw (9.5,\x) node {$1$ lb};
+                        \end{tikzpicture}]]>
+                    </latex-image-code>
+                </image>
+            </figure>
+
+            <p>We can see from the above scale that <m>x=3</m> is obviously correct. Removing half of the weight on both sides of the scale is like dividing both sides of an equation by <m>2</m>:
+                <md>
+                    <mrow>2x\amp=6</mrow>
+                    <mrow>\divideunder{2x}{2}\amp=\divideunder{6}{2}</mrow>
+                    <mrow>x\amp=3</mrow>
+                </md>
+            The equivalent equation in this example is <m>x=3</m>, which tells us that the solution to the equation is <m>3</m> and the solution set is <m>\{3\}</m>.
+            </p>
+
+            <remark><p>Note that when we divide each side of an equation by a number, we use the fraction line in place of the division symbol. By <m>\frac{6}{2}=6\div2</m>, we can see the fraction line and division symbol have the same function. The division symbol is rarely used in later math courses.</p></remark>
+
+            <p>Similarly, we could multiply both sides of an equation by <m>2</m>, just like we can keep a scale balanced if we double the weight on both sides. We will summarize these properties.</p>
+
+            <fact xml:id="fact-properties-of-equivalent-equations">
+                <title>Properties of Equivalent Equations</title>
+                <index><main>Properties of Equivalent Equations</main></index>
+                <statement>
+                    <p>If there is an equation <m>a=b</m>, we can do the following obtain an equivalent equation:
+                        <ul>
+                            <li><p>add the same number to each side: <m>a+c=b+c</m></p></li>
+                            <li><p>subtract the same number from each side: <m>a-c=b-c</m></p></li>
+                            <li><p>multiply each side of the equation by the same number: <m>ac=bc</m></p></li>
+                            <li><p>divide each side of the equation by the same non-zero number: <m>\frac{a}{c}=\frac{b}{c}</m></p></li>
+                        </ul>
+                    </p>
+                </statement>
+            </fact>
+        </subsubsection>
+    </subsection>
+
+
+    <subsection>
+        <title>Solving One-Step Equations and Stating Solution Sets</title>
+
+           <p>Notice that when we solve an equation, the final equation looks like <m>x=3</m>, where the variable <m>x</m> is separated from other numbers and stands alone on one side of the equal sign. The goal of solving any equation is to <em>isolate the variable</em> in this same manner.</p>
+
+           <p>Putting together both strategies (applying the opposite operation and balancing equations like a scale) that we just explored, we will summarize how to solve a one-step linear equation.</p>
+
+        <list xml:id="list-solve-one-step-equation-strategy">
+            <title>Steps to Solving Simple (One-Step) Linear Equations</title>
+            <dl>
+                <li><title>Apply</title><p>Apply the opposite operation to both sides of the equation.</p></li>
+                <li><title>Check</title><p>Check the solution.</p></li>
+                <li><title>Summarize</title><p>State the solution set or (in the case of application problems) summarize the result using a complsentence and appropriate units.</p></li>
+            </dl>
+        </list>
 
         <p>Let's look at a few examples.</p>
 
         <example>
-        	<statement>
-        		<p>Solve for <m>y</m> in the equation <m>7+y=3</m>.</p>
-			</statement>
-			<solution>
-	        	<p>To isolate <m>y</m>, we need to remove <m>7</m> from the left side. Since <m>7</m> is positive, we need to subtract <m>7</m> from each side of the equation. If we make the mistake of adding <m>7</m> on both sides of the equal sign, we would have <m>14+y=10</m>, which will not help us solve for <m>y</m>.</p>
+            <statement>
+                <p>Solve for <m>y</m> in the equation <m>7+y=3</m>.</p>
+            </statement>
+            <solution>
+                <p>To isolate <m>y</m>, we need to remove <m>7</m> from the left side. Since <m>7</m> is positive, we need to subtract <m>7</m> from each side of the equation. If we make the mistake of adding <m>7</m> on both sides of the equal sign, we would have <m>14+y=10</m>, which will not help us solve for <m>y</m>.</p>
 
-	        	<p>Here is how to solve this equation:
-	        		<md>
-		        		<mrow>7+y\amp=3</mrow>
-		        		<mrow>7+y\highlight{{}-7}\amp=3\highlight{{}-7}</mrow>
-		        		<mrow>y\amp=-4</mrow>
-		        	</md>
-		        </p>
+                <p>Here is how to solve this equation:
+                    <md>
+                        <mrow>7+y\amp=3</mrow>
+                        <mrow>7+y\subtractright{7}\amp=3\subtractright{7}</mrow>
+                        <mrow>y\amp=-4</mrow>
+                    </md>
+                </p>
 
-	        	<p>We should always check the solution when we solve equations. For this problem, we will substitute <m>y</m> in the original equationwith <m>-4</m>:
-	        		<md>
-		        		<mrow>7+y\amp=3</mrow>
-		        		<mrow>7+(-4)\amp\stackrel{?}{=}3</mrow>
-		        		<mrow>3\amp\stackrel{\checkmark}{=}3</mrow>
-		        	</md>
-		        </p>
-				
-	        	<p>The solution <m>-4</m> is checked, so the solution set is <m>\{-4\}</m>.</p>
-        	</solution>
+                <p>We should always check the solution when we solve equations. For this problem, we will substitute <m>y</m> in the original equationwith <m>-4</m>:
+                    <md>
+                        <mrow>7+y\amp=3</mrow>
+                        <mrow>7+(-4)\amp\stackrel{?}{=}3</mrow>
+                        <mrow>3\amp\stackrel{\checkmark}{=}3</mrow>
+                    </md>
+                </p>
+                
+                <p>The solution <m>-4</m> is checked, so the solution set is <m>\{-4\}</m>.</p>
+            </solution>
         </example>
 
-	       <example>
-	       	<statement>
-	       		<p>Solve for <m>z</m> in the equation <m>-7+z=5</m>.</p>
-			</statement>
-			<solution>
-	        	<p>To remove <m>-7</m> on the left side, we need to <em>add</em> <m>7</m> to each side of the equation. If we make the mistake of subtracting <m>7</m> from each side, we would still have <m>-7+z-7=-14+z</m> on the left side, which would not isolate <m>z</m>.</p>
+           <example>
+               <statement>
+                   <p>Solve for <m>z</m> in the equation <m>-7+z=5</m>.</p>
+            </statement>
+            <solution>
+                <p>To remove <m>-7</m> on the left side, we need to <em>add</em> <m>7</m> to each side of the equation. If we make the mistake of subtracting <m>7</m> from each side, we would still have <m>-7+z-7=-14+z</m> on the left side, which would not isolate <m>z</m>.</p>
 
-	        	<p>Here is how to solve this equation:
-	        		<md>
-		        		<mrow>-7+z\amp=5</mrow>
-		        		<mrow>-7+z\highlight{{}+7}\amp=5\highlight{{}+7}</mrow>
-		        		<mrow>z\amp=12</mrow>
-		        	</md>
-		        </p>
+                <p>Here is how to solve this equation:
+                    <md>
+                        <mrow>-7+z\amp=5</mrow>
+                        <mrow>-7+z\addright{7}\amp=5\addright{7}</mrow>
+                        <mrow>z\amp=12</mrow>
+                    </md>
+                </p>
 
-	        	<p>We will check the solution by substituting <m>z</m> in the original equation with <m>12</m>:
-	        		<md>
-	        			<mrow>-7+z\amp=5</mrow>
-	        			<mrow>-7+(12)\amp\stackrel{?}{=}5</mrow>
-	        			<mrow>5\amp\stackrel{\checkmark}{=}5</mrow>
-	        		</md>
-	        	</p>
+                <p>We will check the solution by substituting <m>z</m> in the original equation with <m>12</m>:
+                    <md>
+                        <mrow>-7+z\amp=5</mrow>
+                        <mrow>-7+(12)\amp\stackrel{?}{=}5</mrow>
+                        <mrow>5\amp\stackrel{\checkmark}{=}5</mrow>
+                    </md>
+                </p>
 
-	        	<p>The solution <m>12</m> is checked and the solution set is <m>\{12\}</m>.</p>
-			</solution>
+                <p>The solution <m>12</m> is checked and the solution set is <m>\{12\}</m>.</p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-        		<p>Solve for <m>g</m> in <m>\frac{2}{3}+g=\frac{1}{2}</m>.</p>
-			</statement>
-			<solution>
-	        	<p>In a later section (<xref ref="section-solving-linear-equations-and-inequalities-with-fractions">Section</xref>), we will learn a skill to avoid fraction operations in equations like this one. For now, let's solve the equation by using subtraction to isolate <m>g</m>:
-	        		<md>
-		        		<mrow>\frac{2}{3}+g\amp=\frac{1}{2}</mrow>
-		        		<mrow>\frac{2}{3}+g\highlight{{}-\frac{2}{3}}\amp=\frac{1}{2}\highlight{{}-\frac{2}{3}}</mrow>
-		        		<mrow>g\amp=\frac{3}{6}-\frac{4}{6}</mrow>
-		        		<mrow>g\amp=-\frac{1}{6}</mrow>
-		        	</md>
-		        </p>
+            <statement>
+                <p>Solve for <m>g</m> in <m>\frac{2}{3}+g=\frac{1}{2}</m>.</p>
+            </statement>
+            <solution>
+                <p>In a later section (<xref ref="section-solving-linear-equations-and-inequalities-with-fractions">Section</xref>), we will learn a skill to avoid fraction operations in equations like this one. For now, let's solve the equation by using subtraction to isolate <m>g</m>:
+                    <md>
+                        <mrow>\frac{2}{3}+g\amp=\frac{1}{2}</mrow>
+                        <mrow>\frac{2}{3}+g\subtractright{\frac{2}{3}}\amp=\frac{1}{2}\subtractright{\frac{2}{3}}</mrow>
+                        <mrow>g\amp=\frac{3}{6}-\frac{4}{6}</mrow>
+                        <mrow>g\amp=-\frac{1}{6}</mrow>
+                    </md>
+                </p>
 
-	        	<p>We will check the solution by substituting <m>g</m> in the original equation with <m>-\frac{1}{6}</m>:
-	        		<md>
-		        		<mrow>\frac{2}{3}+g\amp=\frac{1}{2}</mrow>
-	        			<mrow>\frac{2}{3}+\left(-\frac{1}{6}\right)\amp\stackrel{?}{=}\frac{1}{2}</mrow>
-	        			<mrow>\frac{4}{6}+\left(-\frac{1}{6}\right)\amp\stackrel{?}{=}\frac{1}{2}</mrow>
-	        			<mrow>\frac{3}{6}\amp\stackrel{?}{=}\frac{1}{2}</mrow>
-	        			<mrow>\frac{1}{2}\amp\stackrel{\checkmark}{=}\frac{1}{2}</mrow>
-	        		</md>
-	        	</p>
+                <p>We will check the solution by substituting <m>g</m> in the original equation with <m>-\frac{1}{6}</m>:
+                    <md>
+                        <mrow>\frac{2}{3}+g\amp=\frac{1}{2}</mrow>
+                        <mrow>\frac{2}{3}+\left(-\frac{1}{6}\right)\amp\stackrel{?}{=}\frac{1}{2}</mrow>
+                        <mrow>\frac{4}{6}+\left(-\frac{1}{6}\right)\amp\stackrel{?}{=}\frac{1}{2}</mrow>
+                        <mrow>\frac{3}{6}\amp\stackrel{?}{=}\frac{1}{2}</mrow>
+                        <mrow>\frac{1}{2}\amp\stackrel{\checkmark}{=}\frac{1}{2}</mrow>
+                    </md>
+                </p>
 
-	        	<p>The solution <m>g=-\frac{1}{6}</m> is checked and the solution set is <m>\left\{-\frac{1}{6}\right\}</m>.</p>
-			</solution>
+                <p>The solution <m>g=-\frac{1}{6}</m> is checked and the solution set is <m>\left\{-\frac{1}{6}\right\}</m>.</p>
+            </solution>
         </example>
 
 
         <example xml:id="example-solve-equation-solution-on-left">
-        	<statement>
-        		<p>Solve for <m>a</m> in the equation <m>10=-2a</m>.</p>
-			</statement>
-			<solution>
-	        	<p>To isolate the variable <m>a</m>, we need to divide each side by <m>-2</m>. We know this as the expression on the right-hand side of the equation contains <m>-2</m> <em>times</em> <m>a</m>. One common mistake is to add <m>2</m> to each side. This would not isolate <m>a</m>, but would instead leave us with the expression <m>-2a+2</m> on the right-hand side.</p>
+            <statement>
+                <p>Solve for <m>a</m> in the equation <m>10=-2a</m>.</p>
+            </statement>
+            <solution>
+                <p>To isolate the variable <m>a</m>, we need to divide each side by <m>-2</m>. We know this as the expression on the right-hand side of the equation contains <m>-2</m> <em>times</em> <m>a</m>. One common mistake is to add <m>2</m> to each side. This would not isolate <m>a</m>, but would instead leave us with the expression <m>-2a+2</m> on the right-hand side.</p>
 
-	        	<p>Here is how to solve this equation:<md>
-	        		<mrow>10\amp=-2a</mrow>
-	        		<mrow>\frac{10}{\highlight{{}-2}}\amp=\frac{-2a}{\highlight{{}-2}}</mrow>
-	        		<mrow>-5\amp=a</mrow>
-	        	</md></p>
+                <p>Here is how to solve this equation:<md>
+                    <mrow>10\amp=-2a</mrow>
+                    <mrow>\frac{10}{\subtractright{2}}\amp=\frac{-2a}{\subtractright{2}}</mrow>
+                    <mrow>-5\amp=a</mrow>
+                </md></p>
 
-				<p>We will check the solution by substituting <m>a</m> in the original equation with <m>-5</m>:
-					<md>
-		        		<mrow>10\amp=-2a</mrow>
-		        		<mrow>10\amp\stackrel{?}{=}-2(-5)</mrow>
-		        		<mrow>10\amp\stackrel{\checkmark}{=}10</mrow>
-		        	</md>
-		        </p>
+                <p>We will check the solution by substituting <m>a</m> in the original equation with <m>-5</m>:
+                    <md>
+                        <mrow>10\amp=-2a</mrow>
+                        <mrow>10\amp\stackrel{?}{=}-2(-5)</mrow>
+                        <mrow>10\amp\stackrel{\checkmark}{=}10</mrow>
+                    </md>
+                </p>
 
-	        	<p>The solution <m>-5</m> is checked and the solution set is <m>\{-5\}</m>.</p>
-			</solution>
-        </example>
-
-		<remark>
-			<p>Note that in solving the equation in <xref ref="example-solve-equation-solution-on-left">Example</xref> we found that <m>-5=a</m> which is equivalent to <m>a=-5</m>. We did not write <m>a=-5</m> as an extra step though, as <m>-5=a</m> identified the solution.</p>
-		</remark>
-
-        <example>
-        	<statement>
-      			<p>A circle's circumference formula is <m>C=\pi d</m>, where <m>C</m> stands for circumference, <m>d</m> stands for diameter, and <m>\pi</m> is a constant with the value of <m>3.1415926...</m>. If a circle's circumference is <quantity><mag>12\pi</mag><unit base="foot"/></quantity>, find this circle's diameter and radius.</p>
-			</statement>
-			<solution>
-        		<p>The circumference is given as <m>12\pi</m> square feet. Approximating <m>\pi</m> with <m>3.14</m> this means the circumference is approximately <quantity><mag>37.68</mag><unit base="foot"/></quantity>. However, if we use <m>3.14</m> for <m>\pi</m>, the result would not be as accurate as <m>12\pi</m> any more. This is why we will use <m>\pi</m> throughout solving the equation and round only in the last step (if necessary).</p>
-
-	        	<p>To solve, we will substitute <m>C</m> in the formula with <m>12\pi</m> and solve for <m>d</m>:
-	        		<md>
-		        		<mrow>C\amp=\pi d</mrow>
-		        		<mrow>12\pi\amp=\pi d</mrow>
-		        		<mrow>\frac{12\pi}{\highlight{\pi}}\amp=\frac{\pi d}{]highlight{\pi}}</mrow>
-		        		<mrow>12\amp=d</mrow> 
-	        		</md>
-	        	</p>
-	
-	        	<p>The circle's diameter is <quantity><mag>12</mag><unit base="foot"/></quantity>. Its radius is half the diameter, <quantity><mag>6</mag><unit base="foot"/></quantity>.</p>
-			</solution>
-        </example>
-
-        <example>
-        	<statement>
-        		<p>Solve for <m>b</m> in <m>-b=2</m>.</p>
-		</statement>
-		<solution>
-	        	<p>Note that the variable <m>b</m> has not been separated yet as there is a negative sign in front of it. The key to solving for <m>b</m> is to recognize that the coefficient of <m>-b</m> is <m>-1</m>. We can then isolate <m>b</m> by dividing each side by <m>-1</m>:
-	        		<md>
-		        		<mrow>-b\amp=2</mrow>
-		        		<mrow>-1\cdot b\amp=2</mrow>
-		        		<mrow>\frac{-1\cdot b}{\highlight{{}-1}}\amp=\frac{2}{\highlight{{}-1}}</mrow>
-		        		<mrow>b\amp=-2</mrow>
-		        	</md>
-		        </p>
-
-	        	<p>We removed <m>-1</m> from <m>-b</m> by the fact <m>\frac{-1}{-1}=1</m>. A second way to remove <m>-1</m> from <m>-b</m> is to multiply both sides by <m>-1</m>, because <m>(-1)(-1)=1</m>. This method is sometimes preferred as multiplication is generally easier than division. Solving this way, we'd get:
-	        		<md>
-		        		<mrow>-b\amp=2</mrow>
-		        		<mrow>-1\cdot b\amp=2</mrow>
-		        		<mrow>\highlight{(-1)\cdot{}}(-1)\cdot b\amp=\highlight{(-1)\cdot{}}2</mrow>
-		        		<mrow>b\amp=-2</mrow>
-		        	</md>
-		        </p>
-
-				<p>We will check the solution by substituting <m>b</m> in the original equation with <m>-2</m>:
-					<md>
-		        		<mrow>-b\amp=2</mrow>
-		        		<mrow>-(-2)\amp\stackrel{?}{=}2</mrow>
-		        		<mrow>2\amp\stackrel{\checkmark}{=}2</mrow>
-		        	</md>
-		        </p>
-
-	        	<p>The solution <m>-2</m> is checked and the solution set is <m>\{-2\}</m>.</p>
-        	</solution>
-        </example>
-
-	    <exercise>
-	        <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare10.pg" seed="2"/>
-	    </exercise>
-		<exercise>
-	        <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="2"/>
-	    </exercise>
-	    <exercise>
-	        <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv30.pg" seed="2"/>
-	    </exercise>
-	</subsection>
-
-	<subsection>
-		<title>Solving One-Step Equations Involving Fractions</title>
-	        <example xml:id="example-one-step-equation-fraction-type-one">
-	        	<statement>
-		        	<p>Solve for <m>c</m> in <m>\frac{c}{5}=4</m>.</p>
-				</statement>
-				<solution>	
-		        	<p>Note that the fraction line here implies division. The opposite operation of division is multiplication, so we multiply both sides by <m>5</m>:<md>
-		        		<mrow>\frac{c}{5}\amp=4</mrow>
-		        		<mrow>\highlight{5\cdot{}}\frac{c}{5}\amp=\highlight{5\cdot{}}4</mrow>
-		        		<mrow>\frac{5}{1}\cdot \frac{c}{5}\amp=20</mrow>
-		        		<mrow>c\amp=20</mrow>
-		        	</md></p>
-
-					<p>We will check the solution by substituting <m>c</m> in the original equation with <m>20</m>:
-						<md>
-			        		<mrow>\frac{c}{5}\amp=4</mrow>
-			        		<mrow>\frac{20}{5}\amp\stackrel{?}{=}4</mrow>
-			        		<mrow>4\amp\stackrel{\checkmark}{=}4</mrow>
-			        	</md>
-			        </p>
-
-		        	<p>The solution <m>20</m> is checked and the solution set is <m>\{20\}</m>.</p>
-		        </solution>
-	        </example>
-
-        <example xml:id="example-one-step-equation-fraction-type-two">
-        	<statement>
-        		<p>Solve for <m>d</m> in <m>-\frac{1}{3}d=6</m>.</p>
-			</statement>
-			<solution>
-	        	<p>To remove <m>-\frac{1}{3}</m>, we could divide each side by <m>-\frac{1}{3}</m> as shown:
-					<md>
-		        		<mrow>-\frac{1}{3}d\amp=6</mrow>
-		        		<mrow>\frac{-\frac{1}{3}d}{\highlight{-\frac{1}{3}{}}}\amp=\frac{6}{\highlight{-\frac{1}{3}{}}}</mrow>
-		        		<mrow>d\amp=\frac{6}{1}\cdot\frac{-3}{1}</mrow>
-		        		<mrow>d\amp=-18</mrow>
-					</md>
-				</p>
-				<p>Another (simpler) approach to isolating <m>d</m> is to instead multiply each side by <m>-3</m>. We will note that this will isolate <m>d</m> as <m>(-3)\cdot \left(-\frac{1}{3}\right)=1</m>. Approaching the problem this way, we get:
-					<md>
-		        		<mrow>-\frac{1}{3}d\amp=6</mrow>
-		        		<mrow>\highlight{(-3)\cdot{}}\left(-\frac{1}{3}d\right)\amp=\highlight{(-3)\cdot{}}6</mrow>
-		        		<mrow>d\amp=-18</mrow>
-					</md>
-		        </p>
-
-				<p>We will check the solution by substituting <m>d</m> in the original equation with <m>-18</m>:
-					<md>
-		        		<mrow>-\frac{1}{3}d\amp=6</mrow>
-		        		<mrow>-\frac{1}{3}\cdot(-18)\amp\stackrel{?}{=}6</mrow>
-		        		<mrow>6\amp\stackrel{\checkmark}{=}6</mrow>
-		        	</md>
-		        </p>
-
-	        	<p>The solution <m>-18</m> is checked and the solution set is <m>\{-18\}</m>.</p>
-        	</solution>
+                <p>The solution <m>-5</m> is checked and the solution set is <m>\{-5\}</m>.</p>
+            </solution>
         </example>
 
         <remark>
-        	<p>To solve an equation containing a fraction, such as <xref ref="example-one-step-equation-fraction-type-one">Example</xref>, we multiplied each side of the equation by <m>5</m>. The denominator was used to determine this factor,  and with more complicated equations containing more than one fraction we will multiply each side of the equation by the least common denominator of all denomoniators contained in that equation.
-        	</p>
+            <p>Note that in solving the equation in <xref ref="example-solve-equation-solution-on-left">Example</xref> we found that <m>-5=a</m> which is equivalent to <m>a=-5</m>. We did not write <m>a=-5</m> as an extra step though, as <m>-5=a</m> identified the solution.</p>
+        </remark>
+
+        <example>
+            <statement>
+                  <p>A circle's circumference formula is <m>C=\pi d</m>, where <m>C</m> stands for circumference, <m>d</m> stands for diameter, and <m>\pi</m> is a constant with the value of <m>3.1415926...</m>. If a circle's circumference is <quantity><mag>12\pi</mag><unit base="foot"/></quantity>, find this circle's diameter and radius.</p>
+            </statement>
+            <solution>
+                <p>The circumference is given as <m>12\pi</m> square feet. Approximating <m>\pi</m> with <m>3.14</m> this means the circumference is approximately <quantity><mag>37.68</mag><unit base="foot"/></quantity>. However, if we use <m>3.14</m> for <m>\pi</m>, the result would not be as accurate as <m>12\pi</m> any more. This is why we will use <m>\pi</m> throughout solving the equation and round only in the last step (if necessary).</p>
+
+                <p>To solve, we will substitute <m>C</m> in the formula with <m>12\pi</m> and solve for <m>d</m>:
+                    <md>
+                        <mrow>C\amp=\pi d</mrow>
+                        <mrow>12\pi\amp=\pi d</mrow>
+                        <mrow>\divideunder{12\pi}{\pi}\amp=\divideunder{\pi d}{\pi}</mrow>
+                        <mrow>12\amp=d</mrow> 
+                    </md>
+                </p>
+    
+                <p>The circle's diameter is <quantity><mag>12</mag><unit base="foot"/></quantity>. Its radius is half the diameter, <quantity><mag>6</mag><unit base="foot"/></quantity>.</p>
+            </solution>
+        </example>
+
+        <example>
+            <statement>
+                <p>Solve for <m>b</m> in <m>-b=2</m>.</p>
+        </statement>
+        <solution>
+                <p>Note that the variable <m>b</m> has not been separated yet as there is a negative sign in front of it. The key to solving for <m>b</m> is to recognize that the coefficient of <m>-b</m> is <m>-1</m>. We can then isolate <m>b</m> by dividing each side by <m>-1</m>:
+                    <md>
+                        <mrow>-b\amp=2</mrow>
+                        <mrow>-1\cdot b\amp=2</mrow>
+                        <mrow>\frac{-1\cdot b}{\subtractright{1}}\amp=\frac{2}{\subtractright{1}}</mrow>
+                        <mrow>b\amp=-2</mrow>
+                    </md>
+                </p>
+
+                <p>We removed <m>-1</m> from <m>-b</m> by the fact <m>\frac{-1}{-1}=1</m>. A second way to remove <m>-1</m> from <m>-b</m> is to multiply both sides by <m>-1</m>, because <m>(-1)(-1)=1</m>. This method is sometimes preferred as multiplication is generally easier than division. Solving this way, we'd get:
+                    <md>
+                        <mrow>-b\amp=2</mrow>
+                        <mrow>-1\cdot b\amp=2</mrow>
+                        <mrow>\multiplyleft{(-1)}(-1)\cdot b\amp=\multiplyleft{(-1)}2</mrow>
+                        <mrow>b\amp=-2</mrow>
+                    </md>
+                </p>
+
+                <p>We will check the solution by substituting <m>b</m> in the original equation with <m>-2</m>:
+                    <md>
+                        <mrow>-b\amp=2</mrow>
+                        <mrow>-(-2)\amp\stackrel{?}{=}2</mrow>
+                        <mrow>2\amp\stackrel{\checkmark}{=}2</mrow>
+                    </md>
+                </p>
+
+                <p>The solution <m>-2</m> is checked and the solution set is <m>\{-2\}</m>.</p>
+            </solution>
+        </example>
+
+        <exercise>
+            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare10.pg" seed="2"/>
+        </exercise>
+        <exercise>
+            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="2"/>
+        </exercise>
+        <exercise>
+            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv30.pg" seed="2"/>
+        </exercise>
+    </subsection>
+
+    <subsection>
+        <title>Solving One-Step Equations Involving Fractions</title>
+            <example xml:id="example-one-step-equation-fraction-type-one">
+                <statement>
+                    <p>Solve for <m>c</m> in <m>\frac{c}{5}=4</m>.</p>
+                </statement>
+                <solution>    
+                    <p>Note that the fraction line here implies division. The opposite operation of division is multiplication, so we multiply both sides by <m>5</m>:<md>
+                        <mrow>\frac{c}{5}\amp=4</mrow>
+                        <mrow>\multiplyleft{5}\frac{c}{5}\amp=\multiplyleft{5}4</mrow>
+                        <mrow>\frac{5}{1}\cdot \frac{c}{5}\amp=20</mrow>
+                        <mrow>c\amp=20</mrow>
+                    </md></p>
+
+                    <p>We will check the solution by substituting <m>c</m> in the original equation with <m>20</m>:
+                        <md>
+                            <mrow>\frac{c}{5}\amp=4</mrow>
+                            <mrow>\frac{20}{5}\amp\stackrel{?}{=}4</mrow>
+                            <mrow>4\amp\stackrel{\checkmark}{=}4</mrow>
+                        </md>
+                    </p>
+
+                    <p>The solution <m>20</m> is checked and the solution set is <m>\{20\}</m>.</p>
+                </solution>
+            </example>
+
+        <example xml:id="example-one-step-equation-fraction-type-two">
+            <statement>
+                <p>Solve for <m>d</m> in <m>-\frac{1}{3}d=6</m>.</p>
+            </statement>
+            <solution>
+                <p>To remove <m>-\frac{1}{3}</m>, we could divide each side by <m>-\frac{1}{3}</m> as shown:
+                    <md>
+                        <mrow>-\frac{1}{3}d\amp=6</mrow>
+                        <mrow>\divideunder{-\frac{1}{3}d}{-\frac{1}{3}}\amp=\divideunder{6}{-\frac{1}{3}}</mrow>
+                        <mrow>d\amp=\frac{6}{1}\cdot\frac{-3}{1}</mrow>
+                        <mrow>d\amp=-18</mrow>
+                    </md>
+                </p>
+                <p>Another (simpler) approach to isolating <m>d</m> is to instead multiply each side by <m>-3</m>. We will note that this will isolate <m>d</m> as <m>(-3)\cdot \left(-\frac{1}{3}\right)=1</m>. Approaching the problem this way, we get:
+                    <md>
+                        <mrow>-\frac{1}{3}d\amp=6</mrow>
+                        <mrow>\multiplyleft{(-3)}\left(-\frac{1}{3}d\right)\amp=\multiplyleft{(-3)}6</mrow>
+                        <mrow>d\amp=-18</mrow>
+                    </md>
+                </p>
+
+                <p>We will check the solution by substituting <m>d</m> in the original equation with <m>-18</m>:
+                    <md>
+                        <mrow>-\frac{1}{3}d\amp=6</mrow>
+                        <mrow>-\frac{1}{3}\cdot(-18)\amp\stackrel{?}{=}6</mrow>
+                        <mrow>6\amp\stackrel{\checkmark}{=}6</mrow>
+                    </md>
+                </p>
+
+                <p>The solution <m>-18</m> is checked and the solution set is <m>\{-18\}</m>.</p>
+            </solution>
+        </example>
+
+        <remark>
+            <p>To solve an equation containing a fraction, such as <xref ref="example-one-step-equation-fraction-type-one">Example</xref>, we multiplied each side of the equation by <m>5</m>. The denominator was used to determine this factor,  and with more complicated equations containing more than one fraction we will multiply each side of the equation by the least common denominator of all denomoniators contained in that equation.
+            </p>
         </remark>
 
         <remark>
-        	<p>In the two examples above (<xref ref="example-one-step-equation-fraction-type-one">Example</xref> and <xref ref="example-one-step-equation-fraction-type-two">Example</xref>), note that <m>\frac{c}{5}</m> is equivalent to <m>\frac{1}{5}c</m> and <m>\frac{1}{3}d</m> is equivalent to <m>\frac{d}{3}</m>. This should make sense because
-			<md>
-				<mrow>\frac{c}{5}\amp=\frac{1}{5}\cdot\frac{c}{1}</mrow>
-				<mrow>\amp=\frac{1}{5}c</mrow>
-			</md>
-			and
-			<md>
-				<mrow>\frac{1}{3}d\amp=\frac{1}{3}\cdot\frac{d}{1}</mrow>
-				<mrow>\amp=\frac{d}{3}</mrow>
-			</md>				
-        	Here are a few more equivalent expressions with fractions:
-        	<md>
-		        	<mrow>\frac{3}{4}x=\frac{3x}{4}</mrow>
-	        	<mrow>\frac{2}{5}x=\frac{2x}{5}</mrow>
-	        	<mrow>\frac{x}{7}\cdot9=\frac{9x}{7}</mrow>
-	        </md>
-    		</p>
-    	</remark>
+            <p>In the two examples above (<xref ref="example-one-step-equation-fraction-type-one">Example</xref> and <xref ref="example-one-step-equation-fraction-type-two">Example</xref>), note that <m>\frac{c}{5}</m> is equivalent to <m>\frac{1}{5}c</m> and <m>\frac{1}{3}d</m> is equivalent to <m>\frac{d}{3}</m>. This should make sense because
+            <md>
+                <mrow>\frac{c}{5}\amp=\frac{1}{5}\cdot\frac{c}{1}</mrow>
+                <mrow>\amp=\frac{1}{5}c</mrow>
+            </md>
+            and
+            <md>
+                <mrow>\frac{1}{3}d\amp=\frac{1}{3}\cdot\frac{d}{1}</mrow>
+                <mrow>\amp=\frac{d}{3}</mrow>
+            </md>                
+            Here are a few more equivalent expressions with fractions:
+            <md>
+                    <mrow>\frac{3}{4}x=\frac{3x}{4}</mrow>
+                <mrow>\frac{2}{5}x=\frac{2x}{5}</mrow>
+                <mrow>\frac{x}{7}\cdot9=\frac{9x}{7}</mrow>
+            </md>
+            </p>
+        </remark>
 
-	    <exercise>
-	        <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv50.pg" seed="2"/>
-	    </exercise>
+        <exercise>
+            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv50.pg" seed="2"/>
+        </exercise>
 
    </subsection>
 
 
  
     <exercises>
-    	<title>Solving One-Step Equations</title>
-    	<exercisegroup>
-	        <introduction><p>Solving One-Step Equations with Addition/Subtraction</p></introduction>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract180.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract100.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract140.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract150.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract160.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="1"/>
-	        </exercise>
-	    </exercisegroup>
+        <title>Solving One-Step Equations</title>
+        <exercisegroup>
+            <introduction><p>Solving One-Step Equations with Addition/Subtraction</p></introduction>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepCompare20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract180.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract100.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract140.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract150.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract160.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepAddSubtract130.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
 
-	    <exercisegroup>
-	    	<introduction><p>Solving One-Step Equations with Multiplication/Division</p></introduction>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv180.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv190.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv200.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv50.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv60.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv80.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv90.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv100.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv110.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv120.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv130.pg" seed="1"/>
-	        </exercise>
-	    </exercisegroup>
+        <exercisegroup>
+            <introduction><p>Solving One-Step Equations with Multiplication/Division</p></introduction>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv180.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv190.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv200.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv50.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv60.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv80.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv90.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv100.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv110.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv120.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/SolveLinearEquations/solveLinearEqnOneStepMultiDiv130.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
     </exercises>
 </section>

--- a/src/section-solving-one-step-inequalities.mbx
+++ b/src/section-solving-one-step-inequalities.mbx
@@ -19,7 +19,7 @@
     <title>Solving One-Step Inequalities</title>
 
     <introduction>
-    	<p>We have learned how to check whether a number is a solution of an equation or inequality. In this section, we will learn how to solve basic equations and inequalities. We will start with a video lecture.</p>
+        <p>We have learned how to check whether a number is a solution of an equation or inequality. In this section, we will learn how to solve basic equations and inequalities. We will start with a video lecture.</p>
 
         <figure>
             <caption>Alternative Video Lesson</caption>
@@ -28,29 +28,29 @@
     </introduction>
 
     <subsection>
-    	<title>Introduction</title>
+        <title>Introduction</title>
 
-    	<p>We will check whether we can use the same properties in <xref ref="fact-properties-of-equivalent-equations">Fact</xref> when we solve inequalities. We can quickly verify that the following properties will still work:
-	    	<md>
-	    		<mrow>\text{If }4\gt2\text{, then:}</mrow>
-	    		<mrow>4+1\amp\stackrel{\checkmark}{\gt}2+1\amp\text{adding the same number on both sides}</mrow>
-	    		<mrow>4-1\amp\stackrel{\checkmark}{\gt}2-1\amp\text{subtracting the same number on both sides}</mrow>
-	    		<mrow>3\cdot4\amp\stackrel{\checkmark}{\gt}3\cdot2\amp\text{multiplying the same positive number on both sides}</mrow>
-	    		<mrow>\frac{4}{2}\amp\stackrel{\checkmark}{\gt}\frac{2}{2}\amp\text{dividing the same positive number on both sides}</mrow>
-	    	</md>
-	    </p>
+        <p>We will check whether we can use the same properties in <xref ref="fact-properties-of-equivalent-equations">Fact</xref> when we solve inequalities. We can quickly verify that the following properties will still work:
+            <md>
+                <mrow>\text{If }4\gt2\text{, then:}</mrow>
+                <mrow>4+1\amp\stackrel{\checkmark}{\gt}2+1\amp\text{adding the same number on both sides}</mrow>
+                <mrow>4-1\amp\stackrel{\checkmark}{\gt}2-1\amp\text{subtracting the same number on both sides}</mrow>
+                <mrow>3\cdot4\amp\stackrel{\checkmark}{\gt}3\cdot2\amp\text{multiplying the same positive number on both sides}</mrow>
+                <mrow>\frac{4}{2}\amp\stackrel{\checkmark}{\gt}\frac{2}{2}\amp\text{dividing the same positive number on both sides}</mrow>
+            </md>
+        </p>
 
-    	<p>However, the inequality no longer holds when we multiply or divide the same <em>negative</em> number on both sides of an inequality:
-    		<md>
-	    		<mrow>4\amp\gt2, \amp\text{ but } (-1)\cdot4 \amp\cancel{\lt} (-1)\cdot2</mrow>
-	    		<mrow>4\amp\gt2, \amp\text{ but } \frac{4}{-1} \amp\cancel{\lt} \frac{2}{-1}</mrow>
-	    	</md>
-	    </p>
+        <p>However, the inequality no longer holds when we multiply or divide the same <em>negative</em> number on both sides of an inequality:
+            <md>
+                <mrow>4\amp\gt2, \amp\text{ but } (-1)\cdot4 \amp\cancel{\lt} (-1)\cdot2</mrow>
+                <mrow>4\amp\gt2, \amp\text{ but } \frac{4}{-1} \amp\cancel{\lt} \frac{2}{-1}</mrow>
+            </md>
+        </p>
 
-    	<p>It's easy to understand why <m>4\gt2</m>, but <m>-4\lt-2</m>. We must apply the following property when we solve inequalities.</p>
+        <p>It's easy to understand why <m>4\gt2</m>, but <m>-4\lt-2</m>. We must apply the following property when we solve inequalities.</p>
 
 
-	    <fact xml:id="fact-changing-direction-of-inequality-sign">
+        <fact xml:id="fact-changing-direction-of-inequality-sign">
             <title>Changing the Direction of the Inequality Sign</title>
             <index><main>Changing the Direction of the Inequality Sign</main></index>
             <statement>
@@ -59,51 +59,51 @@
         </fact>
 
         <example xml:id="example-inequality-one-step-negative-coefficient">
-        	<statement>
-        		<p>Solve <m>-2x\ge12</m> for <m>x</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
-			</statement>
-			<solution>
-	        	<p>To solve this inequality, we will divide each side by <m>-2</m>:
-	        		<md>
-		        		<mrow>-2x\amp\ge12</mrow>
-		        		<mrow>\frac{-2x}{\highlight{-2}}\amp\highlight{\le}\frac{12}{\highlight{-2}}</mrow>
-		        		<mrow>x\amp\le-6</mrow>
-	        		</md>
-	        	</p>
+            <statement>
+                <p>Solve <m>-2x\ge12</m> for <m>x</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
+            </statement>
+            <solution>
+                <p>To solve this inequality, we will divide each side by <m>-2</m>:
+                    <md>
+                        <mrow>-2x\amp\ge12</mrow>
+                        <mrow>\divideunder{-2x}{-2}\amp\highlight{\le{}}\divideunder{12}{-2}</mrow>
+                        <mrow>x\amp\le-6</mrow>
+                    </md>
+                </p>
 
-	        	<p>Note that the step where we divided each side of the inequality by a <em>negative</em> number was when the direction of the inequality sign changed.</p>
+                <p>Note that the step where we divided each side of the inequality by a <em>negative</em> number was when the direction of the inequality sign changed.</p>
 
-	        	<p>When we solve a linear equation, there is usually one solution. When we solve a linear inequality, there are usually infinitely many solutions. For this example, any number smaller than <m>-6</m> or equal to <m>-6</m> is a solution.</p>
+                <p>When we solve a linear equation, there is usually one solution. When we solve a linear inequality, there are usually infinitely many solutions. For this example, any number smaller than <m>-6</m> or equal to <m>-6</m> is a solution.</p>
 
-	        	<p>There are three ways to represent the solution set for the solution to an inequality: graphically, with set-builder notation, and with interval notation. Graphically, we represent the solution set as:
+                <p>There are three ways to represent the solution set for the solution to an inequality: graphically, with set-builder notation, and with interval notation. Graphically, we represent the solution set as:
 
-	           <figure>
-	                <image width="75%">
-	                    <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-	                        \begin{axis}[numberline,
-	                                    xmin=-8,xmax=8,
-	                                    xtick={-8,-6,...,8},
-	                                    minor xtick={-7,-5,...,7}
-	                                    ]
-	                            \addplot[infiniteclosedinterval] coordinates {(-8,0) (-6,0)};
-	                        \end{axis}
-	                    \end{tikzpicture}]]>
-	                    </latex-image-code>
-	                </image>
-	            </figure>
+               <figure>
+                    <image width="75%">
+                        <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \begin{axis}[numberline,
+                                        xmin=-8,xmax=8,
+                                        xtick={-8,-6,...,8},
+                                        minor xtick={-7,-5,...,7}
+                                        ]
+                                \addplot[infiniteclosedinterval] coordinates {(-8,0) (-6,0)};
+                            \end{axis}
+                        \end{tikzpicture}]]>
+                        </latex-image-code>
+                    </image>
+                </figure>
 
-	        	Using interval notation, we write the solution set as <m>(-\infty,-6]</m>. Using set-builder notation, we write the solution set as <m>\{x\mid x\le-6\}</m>.
-				</p>
-	    	</solution>
+                Using interval notation, we write the solution set as <m>(-\infty,-6]</m>. Using set-builder notation, we write the solution set as <m>\{x\mid x\le-6\}</m>.
+                </p>
+            </solution>
         </example>
 
-		<remark>
-		    <p>Since the inequality solved in <xref ref="example-inequality-one-step-negative-coefficient">Example</xref> has infinite solutions, it's difficult to check. We found that all values of <m>x</m> for which <m>x\le-6</m> are solutions, so one approach is to check if <m>-6</m> satisfies the inequality <m>-2x\ge12</m> and additionally if one other number less than <m>-6</m> is a solution to <m>-2x\ge12</m>. Both are shown here:
-		        <md>
-		            <mrow>-2x\amp\ge12</mrow>
-		            <mrow>-2(-6)\amp\stackrel{?}{\ge}12</mrow>
-				    <mrow>12\amp\stackrel{\checkmark}{\ge}12</mrow>
+        <remark>
+            <p>Since the inequality solved in <xref ref="example-inequality-one-step-negative-coefficient">Example</xref> has infinite solutions, it's difficult to check. We found that all values of <m>x</m> for which <m>x\le-6</m> are solutions, so one approach is to check if <m>-6</m> satisfies the inequality <m>-2x\ge12</m> and additionally if one other number less than <m>-6</m> is a solution to <m>-2x\ge12</m>. Both are shown here:
+                <md>
+                    <mrow>-2x\amp\ge12</mrow>
+                    <mrow>-2(-6)\amp\stackrel{?}{\ge}12</mrow>
+                    <mrow>12\amp\stackrel{\checkmark}{\ge}12</mrow>
                  </md> 
             Next, we can check another number smaller than <m>-6</m>, such as <m>-7</m>:
                 <md>
@@ -114,216 +114,216 @@
             </p>
             <p>Thus both <m>-6</m> and <m>-7</m> are solutions. It's important to note that this doesn't directly verify that <em>all</em> solutions to this inequality check. It's valuable though in that it would likely help us catch an error if we had made one. Consult your instructor to see if you're expected to check your answer in this capacity.</p>
         </remark>
-	</subsection>
+    </subsection>
 
-	<subsection>
-		<title>Solving One-Step Inequalities and Stating Solution Sets</title>
+    <subsection>
+        <title>Solving One-Step Inequalities and Stating Solution Sets</title>
 
         <example>
-        	<statement>
-        		<p>Solve <m>t+7\lt5</m> for <m>t</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
-			</statement>
-			<solution>
-	        	<p>To solve this inequality, we will subtract <m>7</m> from each side:
-	        		<md>
-		        		<mrow>t+7\amp\lt5</mrow>
-		        		<mrow>t+7\highlight{{}-7}\amp\lt5\highlight{{}-7}</mrow>
-		        		<mrow>t\amp\lt-2</mrow>
-	        		</md>
-	        	</p>
+            <statement>
+                <p>Solve <m>t+7\lt5</m> for <m>t</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
+            </statement>
+            <solution>
+                <p>To solve this inequality, we will subtract <m>7</m> from each side:
+                    <md>
+                        <mrow>t+7\amp\lt5</mrow>
+                        <mrow>t+7\subtractright{7}\amp\lt5\subtractright{7}</mrow>
+                        <mrow>t\amp\lt-2</mrow>
+                    </md>
+                </p>
 
-	        	<p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
+                <p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
 
-	        	<p>Graphically, we represent this solution set as:
+                <p>Graphically, we represent this solution set as:
 
-	           <figure>
-	                <image width="75%">
-	                    <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-	                        \begin{axis}[numberline,
-	                                    xmin=-8,xmax=8,
-	                                    xtick={-8,-6,...,8},
-	                                    minor xtick={-7,-5,...,7},
-	                                    xlabel={$t$}
-	                                    ]
-	                            \addplot[infiniteopeninterval] coordinates {(-8,0) (-2,0)};
-	                        \end{axis}
-	                    \end{tikzpicture}]]>
-	                    </latex-image-code>
-	                </image>
-	            </figure>
+               <figure>
+                    <image width="75%">
+                        <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \begin{axis}[numberline,
+                                        xmin=-8,xmax=8,
+                                        xtick={-8,-6,...,8},
+                                        minor xtick={-7,-5,...,7},
+                                        xlabel={$t$}
+                                        ]
+                                \addplot[infiniteopeninterval] coordinates {(-8,0) (-2,0)};
+                            \end{axis}
+                        \end{tikzpicture}]]>
+                        </latex-image-code>
+                    </image>
+                </figure>
 
 
-	        	Using interval notation, we write the solution set as <m>(-\infty,-2)</m>. Using set-builder notation, we write the solution set as <m>\{t\mid t\lt-2\}</m>.
-				</p>
-	    	</solution>
+                Using interval notation, we write the solution set as <m>(-\infty,-2)</m>. Using set-builder notation, we write the solution set as <m>\{t\mid t\lt-2\}</m>.
+                </p>
+            </solution>
         </example>
 
 
         <example>
-        	<statement>
-        		<p>Solve <m>x-5\ge-4</m> for <m>x</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
-			</statement>
-			<solution>
-	        	<p>To solve this inequality, we will add <m>5</m> to each side:
-	        		<md>
-		        		<mrow>x-5\amp\ge-4</mrow>
-		        		<mrow>x-5\highlight{{}+5}\amp\lt-4\highlight{{}+5}</mrow>
-		        		<mrow>x\amp\ge1</mrow>
-	        		</md>
-	        	</p>
+            <statement>
+                <p>Solve <m>x-5\ge-4</m> for <m>x</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
+            </statement>
+            <solution>
+                <p>To solve this inequality, we will add <m>5</m> to each side:
+                    <md>
+                        <mrow>x-5\amp\ge-4</mrow>
+                        <mrow>x-5\addright{5}\amp\lt-4\addright{5}</mrow>
+                        <mrow>x\amp\ge1</mrow>
+                    </md>
+                </p>
 
-	        	<p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
+                <p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
 
-	        	<p>Graphically, we represent this solution set as:
+                <p>Graphically, we represent this solution set as:
 
-	           <figure>
-	                <image width="75%">
-	                    <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-	                        \begin{axis}[numberline,
-	                                    xmin=-8,xmax=8,
-	                                    xtick={-8,-6,...,8},
-	                                    minor xtick={-7,-5,...,7}
-	                                    ]
-	                            \addplot[closedinfiniteinterval] coordinates { (1,0) (8,0)};
-	                        \end{axis}
-	                    \end{tikzpicture}]]>
-	                    </latex-image-code>
-	                </image>
-	            </figure>
+               <figure>
+                    <image width="75%">
+                        <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \begin{axis}[numberline,
+                                        xmin=-8,xmax=8,
+                                        xtick={-8,-6,...,8},
+                                        minor xtick={-7,-5,...,7}
+                                        ]
+                                \addplot[closedinfiniteinterval] coordinates { (1,0) (8,0)};
+                            \end{axis}
+                        \end{tikzpicture}]]>
+                        </latex-image-code>
+                    </image>
+                </figure>
 
-	        	Using interval notation, we write the solution set as <m>[1,\infty)</m>. Using set-builder notation, we write the solution set as <m>\{x\mid x\ge1\}</m>.
-				</p>
-	    	</solution>
+                Using interval notation, we write the solution set as <m>[1,\infty)</m>. Using set-builder notation, we write the solution set as <m>\{x\mid x\ge1\}</m>.
+                </p>
+            </solution>
         </example>
 
         <example>
-        	<statement>
-        		<p>Solve <m>\frac{1}{2}z\gt-\frac{5}{2}</m> for <m>z</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
-			</statement>
-			<solution>
-	        	<p>To solve this inequality, we will multiply each side by <m>2</m>:
-	        		<md>
-		        		<mrow>\frac{1}{2}z\amp\gt-\frac{5}{2}</mrow>
-		        		<mrow>\highlight{2\cdot}\left(\frac{1}{2}z\right)\amp\gt\highlight{2\cdot}\left(-\frac{5}{2}\right)</mrow>
-		        		<mrow>z\amp\gt-5</mrow>
-	        		</md>
-	        	</p>
+            <statement>
+                <p>Solve <m>\frac{1}{2}z\gt-\frac{5}{2}</m> for <m>z</m>. State the solution set graphically, using interval notation, and using set-builder notation.</p>
+            </statement>
+            <solution>
+                <p>To solve this inequality, we will multiply each side by <m>2</m>:
+                    <md>
+                        <mrow>\frac{1}{2}z\amp\gt-\frac{5}{2}</mrow>
+                        <mrow>\multiplyleft{2}\left(\frac{1}{2}z\right)\amp\gt\multiplyleft{2}\left(-\frac{5}{2}\right)</mrow>
+                        <mrow>z\amp\gt-5</mrow>
+                    </md>
+                </p>
 
-	        	<p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
+                <p>Note that the direction of the inequality did not change, as we did not divide each side of the inequality by a negative number at any point.</p>
 
-	        	<p>Graphically, we represent this solution set as:
+                <p>Graphically, we represent this solution set as:
 
-	           <figure>
-	                <image width="75%">
-	                    <latex-image-code>
-	                    <![CDATA[\begin{tikzpicture}
-	                        \begin{axis}[numberline,
-	                                    xmin=-8,xmax=8,
-	                                    xtick={-8,-6,...,8},
-	                                    minor xtick={-7,-5,...,7},
-	                                    xlabel={$z$}
-	                                    ]
-	                            \addplot[openinfiniteinterval] coordinates {(-5,0) (8,0)};
-	                        \end{axis}
-	                    \end{tikzpicture}]]>
-	                    </latex-image-code>
-	                </image>
-	            </figure>
+               <figure>
+                    <image width="75%">
+                        <latex-image-code>
+                        <![CDATA[\begin{tikzpicture}
+                            \begin{axis}[numberline,
+                                        xmin=-8,xmax=8,
+                                        xtick={-8,-6,...,8},
+                                        minor xtick={-7,-5,...,7},
+                                        xlabel={$z$}
+                                        ]
+                                \addplot[openinfiniteinterval] coordinates {(-5,0) (8,0)};
+                            \end{axis}
+                        \end{tikzpicture}]]>
+                        </latex-image-code>
+                    </image>
+                </figure>
 
 
-	        	Using interval notation, we write the solution set as <m>(-5,\infty)</m>. Using set-builder notation, we write the solution set as <m>\{z\mid z\gt-5\}</m>.
-				</p>
-	    	</solution>
+                Using interval notation, we write the solution set as <m>(-5,\infty)</m>. Using set-builder notation, we write the solution set as <m>\{z\mid z\gt-5\}</m>.
+                </p>
+            </solution>
         </example>
     </subsection>
 
-    <exercises>   	
+    <exercises>       
         <title>Solving One-Step Inequalities</title>
         <exercisegroup>
-        	<intruction><p>Set-Builder Notation and Interval Notation</p></intruction>
-        	<exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation40.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation60.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation90.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation120.pg" seed="1"/>
-	        </exercise>
-    	</exercisegroup>
+            <intruction><p>Set-Builder Notation and Interval Notation</p></intruction>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SetNotationToGraph40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/GraphToSetAndIntervalNotation40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation40.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation60.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation90.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/IntervalNotation120.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
         <exercisegroup>
-        	<intruction><p>Solving One-Step Inequalities by Addition/Subtraction</p></intruction>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality10.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality20.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality30.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality40.pg" seed="1"/>
-	        </exercise>
-    	</exercisegroup>
-    	<exercisegroup>
-        	<intruction><p>Solving One-Step Inequalities by Multiplication/Division</p></intruction>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality60.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality70.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality80.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality90.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality160.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality120.pg" seed="1"/>
-	        </exercise>
-	        <exercise>
-	            <webwork source="BasicAlgebra/LinearInequalities/SolveInequality140.pg" seed="1"/>
-	        </exercise>
-    	</exercisegroup>
+            <intruction><p>Solving One-Step Inequalities by Addition/Subtraction</p></intruction>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality10.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality20.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality30.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality40.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
+        <exercisegroup>
+            <intruction><p>Solving One-Step Inequalities by Multiplication/Division</p></intruction>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality60.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality70.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality80.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality90.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality160.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality120.pg" seed="1"/>
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/LinearInequalities/SolveInequality140.pg" seed="1"/>
+            </exercise>
+        </exercisegroup>
     </exercises>
 </section>

--- a/src/section-solving-quadratic-equations-by-factoring.mbx
+++ b/src/section-solving-quadratic-equations-by-factoring.mbx
@@ -31,7 +31,7 @@
 
     <p>Let's review how to solve linear equations. For example,<md>
         <mrow>2x-9\amp=1</mrow>
-        <mrow>2x-9\highlight{+9}\amp=1\highlight{+9}</mrow>
+        <mrow>2x-9\addright{9}\amp=1\addright{9}</mrow>
         <mrow>2x\amp=10</mrow>
         <mrow>\frac{2x}{2}\amp=\frac{10}{2}</mrow>
         <mrow>x\amp=5</mrow>
@@ -39,7 +39,7 @@
 
     <p>One key strategy to solve this linear equation is to separate <m>x</m> terms and number terms on both sides of the equal sign, and we got <m>2x=10</m>. Next, we removed <m>2</m> from <m>2x</m> and got the solution <m>x=5</m>. Can we use the same strategy to solve <m>-16t^2+16t+96=0</m>? Let's try:<md>
         <mrow>-16t^2+16t+96\amp=0</mrow>
-        <mrow>-16t^2+16t+96\highlight{-96}\amp=0\highlight{-96}</mrow>
+        <mrow>-16t^2+16t+96\subtractright{96}\amp=0\subtractright{96}</mrow>
         <mrow>-16t^2+16t\amp=-96</mrow>
     </md></p>
 
@@ -68,7 +68,7 @@
         <mrow>-16(t^2-t-6)\amp=0</mrow>
         <mrow>-16(t+2)(t-3)\amp=0</mrow>
         <mrow>t+2=0\amp\text{ or }t-3=0</mrow>
-        <mrow>t+2\highlight{-2}=0\highlight{-2}\amp\text{ or }t-3\highlight{+3}=0\highlight{+3}</mrow>
+        <mrow>t+2\subtractright{2}=0\subtractright{2}\amp\text{ or }t-3\addright{3}=0\addright{3}</mrow>
         <mrow>t=-2\amp\text{ or }t=3</mrow>
     </md></p>
 
@@ -166,7 +166,7 @@
         <solution>
             <p>We may not divide both sides of the equation by <m>x</m>; otherwise we will lose the solution <m>x=0</m>. We should make the equation's right side <m>0</m>, so we can factor and use Zero Product Property.<md>
                 <mrow>2x^2\amp=5x</mrow>
-                <mrow>2x^2\highlight{-5x}\amp=5x\highlight{-5x}</mrow>
+                <mrow>2x^2\subtractright{5x}\amp=5x\subtractright{5x}</mrow>
                 <mrow>2x^2-5x\amp=0</mrow>
                 <mrow>x(2x-5)\amp=0</mrow>
                 <mrow>x=0\amp\text{ or }2x-5=0</mrow>
@@ -183,7 +183,7 @@
         <solution>
             <p>Again, we must make the equation's right side <m>0</m>, so we can factor and use Zero Product Property.<md>
                 <mrow>(x+4)(x-3)\amp=18</mrow>
-                <mrow>(x+4)(x-3)\highlight{-18}\amp=18\highlight{-18}</mrow>
+                <mrow>(x+4)(x-3)\subtractright{18}\amp=18\subtractright{18}</mrow>
                 <mrow>(x+4)(x-3)-18\amp=0</mrow>
                 <mrow>x^2+x-12-18\amp=0</mrow>
                 <mrow>x^2+x-30\amp=0</mrow>
@@ -256,7 +256,7 @@
             <p>A rectangle's area formula is <m>\text{area}=(\text{base})\cdot(\text{height})</m>. Since the bigger rectangle's area is given as <quantity><mag>99</mag><unit base="foot" exp="2"/></quantity>, we can write and solve the equation:<md>
                 <mrow>(7+2x)(5+2x)=99</mrow>
                 <mrow>4x^2+24x+35=99</mrow>
-                <mrow>4x^2+24x+35\highlight{-99}\amp=99\highlight{-99}</mrow>
+                <mrow>4x^2+24x+35\subtractright{99}\amp=99\subtractright{99}</mrow>
                 <mrow>4x^2+24x-64\amp=0</mrow>
                 <mrow>4(x^2+6x-16)\amp=0</mrow>
                 <mrow>4(x+8)(x-2)\amp=0</mrow>

--- a/src/section-solving-quadratic-equations-by-quadratic-formula.mbx
+++ b/src/section-solving-quadratic-equations-by-quadratic-formula.mbx
@@ -119,7 +119,7 @@
 
         <p>Before we use the Quadratic Formula, we must change a quadratic equation into the standard form <m>ax^2+bx+c=0</m> to identify the values of <m>a</m>, <m>b</m> and <m>c</m>. For example, to solve <m>4x+12=x^2</m>, we must first convert it to the standard form:<md>
             <mrow>4x+12\amp=x^2</mrow>
-            <mrow>4x+12\highlight{-4x-12}\amp=x^2\highlight{-4x-12}</mrow>
+            <mrow>4x+12\subtractright{4x}\subtractright{12}\amp=x^2\subtractright{4x}\subtractright{12}</mrow>
             <mrow>0\amp=x^2-4x-12</mrow>
         </md>Now we can identify <m>a=1</m>, <m>b=-4</m> and <m>c=-12</m>.</p>
 
@@ -132,7 +132,7 @@
             <solution>
                 <p>First, we convert the equation into standard form:<md>
                     <mrow>4x^2+9\amp=12x</mrow>
-                    <mrow>4x^2+9\highlight{-12x}\amp=12x\highlight{-12x}</mrow>
+                    <mrow>4x^2+9\subtractright{12x}\amp=12x\subtractright{12x}</mrow>
                     <mrow>4x^2-12x+9\amp=0</mrow>
                 </md>Now we can identify that <m>a=4</m>, <m>b=-12</m> and <m>c=9</m>. We will substitute them into the Quadratic Formula:<md>
                     <mrow>x\amp=\frac{-b\pm\sqrt{b^2-4ac}}{2a}</mrow>

--- a/src/section-solving-quadratic-equations-by-square-root-property.mbx
+++ b/src/section-solving-quadratic-equations-by-square-root-property.mbx
@@ -53,7 +53,7 @@
             <mrow>a^2+b^2\amp=c^2</mrow>
             <mrow>2.1^2+b^2\amp=7.5^2</mrow>
             <mrow>4.41+b^2\amp=56.25</mrow>
-            <mrow>4.41+b^2\highlight{-4.41}\amp=56.25\highlight{-4.41}</mrow>
+            <mrow>4.41+b^2\subtractright{4.41}\amp=56.25\subtractright{4.41}</mrow>
             <mrow>b^2\amp=51.84</mrow>
         </md>To remove the square, we use the following fact:<me>\sqrt{x^2}=x\quad\text{where }x\text{ is positive}</me>We can see square root and square are opposite operations. If we take the square root on both sides of the equation, we have:<md>
             <mrow>b^2\amp=51.84</mrow>
@@ -147,13 +147,13 @@
             <solution>
                 <p><md>
                     <mrow>-40\amp=10-2(p-1)^2</mrow>
-                    <mrow>-40\highlight{-10}\amp=10-2(p-1)^2\highlight{-10}</mrow>
+                    <mrow>-40\subtractright{10}\amp=10-2(p-1)^2\subtractright{10}</mrow>
                     <mrow>-50\amp=-2(p-1)^2</mrow>
                     <mrow>\frac{-50}{-2}\amp=\frac{-2(p-1)^2}{-2}</mrow>
                     <mrow>25\amp=(p-1)^2</mrow>
                     <mrow>\pm\sqrt{25}\amp=\sqrt{(p-1)^2}</mrow>
                     <mrow>\pm5\amp=p-1</mrow>
-                    <mrow>\pm5\highlight{+1}\amp=p-1\highlight{+1}</mrow>
+                    <mrow>\pm5\addright{1}\amp=p-1\addright{1}</mrow>
                     <mrow>\pm5+1\amp=p</mrow>
                     <mrow>p=5+1\amp\text{ or }p=-5+1</mrow>
                     <mrow>p=6\amp\text{ or }p=-4</mrow>
@@ -181,7 +181,7 @@
                     <mrow>\sqrt{(q+2)^2}\amp=\pm\sqrt{12}</mrow>
                     <mrow>q+2\amp=\pm\sqrt{2^2\cdot3}</mrow>
                     <mrow>q+2\amp=\pm2\sqrt{3}</mrow>
-                    <mrow>q+2\highlight{-2}\amp=\pm2\sqrt{3}\highlight{-2}</mrow>
+                    <mrow>q+2\subtractright{2}\amp=\pm2\sqrt{3}\subtractright{2}</mrow>
                     <mrow>q\amp=-2\pm2\sqrt{3}</mrow>
                 </md>We usually leave the square in the solutions. In application problems, we could use a calculator to approximate the solutions to decimals:<md>
                     <mrow>q\amp=-2\pm2\sqrt{3}</mrow>

--- a/src/section-solving-radical-equations.mbx
+++ b/src/section-solving-radical-equations.mbx
@@ -41,11 +41,11 @@
             <mrow>T\amp=2\pi\sqrt{\frac{L}{g}}</mrow>
             <mrow>10\amp=2(3.14)\sqrt{\frac{L}{9.8}}</mrow>
             <mrow>10\amp=6.28\sqrt{\frac{L}{9.8}}</mrow>
-            <mrow>\highlight{\frac{1}{6.28}\cdot}10\amp=\highlight{\frac{1}{6.28}\cdot}6.28\sqrt{\frac{L}{9.8}}\amp\text{separating the radical}</mrow>
+            <mrow>\multiplyleft{\frac{1}{6.28}}10\amp=\multiplyleft{\frac{1}{6.28}}6.28\sqrt{\frac{L}{9.8}}\amp\text{separating the radical}</mrow>
             <mrow>\frac{10}{6.28}\amp=\sqrt{\frac{L}{9.8}}</mrow>
             <mrow>\left(\frac{10}{6.28}\right)^2\amp=\left(\sqrt{\frac{L}{9.8}}\right)^2\amp\text{removing square root by squaring both sides}</mrow>
             <mrow>\frac{100}{6.28^2}\amp=\frac{L}{9.8}</mrow>
-            <mrow>\highlight{9.8\cdot}\frac{100}{6.28^2}\amp=\highlight{9.8\cdot}\frac{L}{9.8}</mrow>
+            <mrow>\multiplyleft{9.8}\frac{100}{6.28^2}\amp=\multiplyleft{9.8}\frac{L}{9.8}</mrow>
             <mrow>24.85\amp\approx L</mrow>
         </md>Solution: To build a pendulum with a period of <m>10</m> seconds, the pendulum's length should be approximately <m>24.85</m> meters.</p>
 
@@ -64,9 +64,9 @@
             <solution>
                 <p>We will separate the radical first, and then square both sides.<md>
                     <mrow>1-\sqrt{y-1}\amp=4</mrow>
-                    <mrow>1-\sqrt{y-1}\highlight{{}-1}\amp=4\highlight{{}-1}</mrow>
+                    <mrow>1-\sqrt{y-1}\subtractright{1}\amp=4\subtractright{1}</mrow>
                     <mrow>-\sqrt{y-1}\amp=3</mrow>
-                    <mrow>\highlight{(-1)\cdot}(-\sqrt{y-1})\amp=\highlight{(-1)\cdot}3</mrow>
+                    <mrow>\multiplyleft{(-1)}(-\sqrt{y-1})\amp=\multiplyleft{(-1)}3</mrow>
                     <mrow>\sqrt{y-1}\amp=-3</mrow>
                     <mrow>\left(\sqrt{y-1}\right)^2\amp=(-3)^2</mrow>
                     <mrow>y-1\amp=9</mrow>
@@ -123,7 +123,7 @@
                     <mrow>\sqrt{p-5}\amp=5-\sqrt{p}</mrow>
                     <mrow>\left(\sqrt{p-5}\right)^2\amp=\left(5-\sqrt{p}\right)^2</mrow>
                     <mrow>p-5\amp=25-10\sqrt{p}+p</mrow>
-                    <mrow>p-5\highlight{{}-p}\amp=25-10\sqrt{p}+p\highlight{{}-p}</mrow>
+                    <mrow>p-5\subtractright{p}\amp=25-10\sqrt{p}+p\subtractright{p}</mrow>
                     <mrow>-5\amp=25-10\sqrt{p}</mrow>
                     <mrow>-30\amp=-10\sqrt{p}</mrow>
                     <mrow>\frac{-30}{-10}\amp=\frac{-10\sqrt{p}}{-10}</mrow>
@@ -148,11 +148,11 @@
             <solution>
                 <p><md>
                     <mrow>T\amp=2\pi\sqrt{\frac{L}{g}}</mrow>
-                    <mrow>\highlight{\frac{1}{2\pi}\cdot}T\amp=\highlight{\frac{1}{2\pi}\cdot}2\pi\sqrt{\frac{L}{g}}</mrow>
+                    <mrow>\multiplyleft{\frac{1}{2\pi}}T\amp=\multiplyleft{\frac{1}{2\pi}}2\pi\sqrt{\frac{L}{g}}</mrow>
                     <mrow>\frac{T}{2\pi}\amp=\sqrt{\frac{L}{g}}</mrow>
                     <mrow>\left(\frac{T}{2\pi}\right)^2\amp=\left(\sqrt{\frac{L}{g}}\right)^2</mrow>
                     <mrow>\frac{T^2}{4\pi^2}\amp=\frac{L}{g}</mrow>
-                    <mrow>\highlight{g\cdot}\frac{T^2}{4\pi^2}\amp=\highlight{g\cdot}\frac{L}{g}</mrow>
+                    <mrow>\multiplyleft{g}\frac{T^2}{4\pi^2}\amp=\multiplyleft{g}\frac{L}{g}</mrow>
                     <mrow>\frac{T^2g}{4\pi^2}\amp=L</mrow>
                 </md></p>
             </solution>

--- a/src/section-solving-rational-equations.mbx
+++ b/src/section-solving-rational-equations.mbx
@@ -37,7 +37,7 @@
 
         <p>The time it takes the boat to travel from Town A to Town B is <m>\frac{12}{v+2}</m>, and <m>\frac{12}{v-2}</m> from Town B to Town A. The function to model the whole trip's time is<me>t(v)=\frac{12}{v-2}+\frac{12}{v+2}</me>where <m>t</m> stands for time in hours. The trip will take <m>8</m> hours, so we substitute <m>t(v)</m> with <m>8</m>, and we have:<me>\frac{12}{v-2}+\frac{12}{v+2}=8</me>Instead of using the function's graph, we will directly solve this equation. Please review the skill of Fraction Buster we learned in <xref ref="subsection-fraction-buster">Subsection</xref>. The same skill applies to rational functions. To remove fractions in this equation, we will multiply both sides of the equation by the common denominator <m>(v-2)(v+2)</m>, and we have:<md>
             <mrow>\frac{12}{v-2}+\frac{12}{v+2}\amp=8</mrow>
-            <mrow>\highlight{(v+2)(v-2)\cdot}(\frac{12}{v-2}+\frac{12}{v+2})\amp=\highlight{(v+2)(v-2)\cdot}8</mrow>
+            <mrow>\multiplyleft{(v+2)(v-2)}(\frac{12}{v-2}+\frac{12}{v+2})\amp=\multiplyleft{(v+2)(v-2)}8</mrow>
             <mrow>(v+2)(v-2)\cdot\frac{12}{v-2}+(v+2)(v-2)\cdot\frac{12}{v+2}\amp=(v+2)(v-2)\cdot8</mrow>
             <mrow>12(v+2)+12(v-2)\amp=8(v^2-4)</mrow>
             <mrow>12v+24+12v-24\amp=8v^2-32</mrow>
@@ -66,7 +66,7 @@
 
                 <p>To remove all fractions, we multiply both sides of the equation by the common denominator of <m>3</m>, <m>6</m> and <m>x</m>, which is <m>6x</m>:<md>
                     <mrow>\frac{1}{3}+\frac{1}{6}\amp=\frac{1}{x}</mrow>
-                    <mrow>\highlight{6x\cdot}(\frac{1}{3}+\frac{1}{6})\amp=\highlight{6x\cdot}\frac{1}{x}</mrow>
+                    <mrow>\multiplyleft{6x}(\frac{1}{3}+\frac{1}{6})\amp=\multiplyleft{6x}\frac{1}{x}</mrow>
                     <mrow>6x\cdot\frac{1}{3}+6x\cdot\frac{1}{6}\amp=6x\cdot\frac{1}{x}</mrow>
                     <mrow>2x+x\amp=6</mrow>
                     <mrow>3x\amp=6</mrow>
@@ -86,7 +86,7 @@
             <solution>
                 <p>In this equation, we can see <m>y\ne-1</m> and <m>y\ne0</m>. The common denominator is <m>y(y+1)</m>. We will multiply both sides of the equation by <m>y(y+1)</m>:<md>
                     <mrow>\frac{2}{y+1}\amp=\frac{3}{y}</mrow>
-                    <mrow>\highlight{y(y+1)\cdot}\frac{2}{y+1}\amp=\highlight{y(y+1)\cdot}\frac{3}{y}</mrow>
+                    <mrow>\multiplyleft{y(y+1)}\frac{2}{y+1}\amp=\multiplyleft{y(y+1)}\frac{3}{y}</mrow>
                     <mrow>2y\amp=3(y+1)</mrow>
                     <mrow>2y\amp=3y+3</mrow>
                     <mrow>-y\amp=3</mrow>
@@ -108,7 +108,7 @@
             <solution>
                 <p>In this equation, we can see <m>z\ne4</m>. The common denominator is <m>z-4</m>. We will multiply both sides of the equation by <m>z-4</m>:<md>
                     <mrow>z+\frac{1}{z-4}\amp=\frac{z-3}{z-4}</mrow>
-                    <mrow>\highlight{(z-4)\cdot}(z+\frac{1}{z-4})\amp=\highlight{(z-4)\cdot}\frac{z-3}{z-4}</mrow>
+                    <mrow>\multiplyleft{(z-4)}(z+\frac{1}{z-4})\amp=\multiplyleft{(z-4)}\frac{z-3}{z-4}</mrow>
                     <mrow>(z-4)\cdot z+(z-4)\cdot\frac{1}{z-4}\amp=z-3</mrow>
                     <mrow>z^2-4z+1\amp=z-3</mrow>
                     <mrow>z^2-5z+4\amp=0</mrow>
@@ -127,7 +127,7 @@
                 <p>To find the common denominator, we need to factor all denominators if possible:<me>\frac{3}{p-2}+\frac{5}{p+2}=\frac{12}{(p+2)(p-2)}</me>Now we can see the common denominator is <m>(p+2)(p-2)</m>, and the domain conditions are <m>p\ne2</m> and <m>p\ne-2</m>. We will multiply both sides of the equation by <m>(p+2)(p-2)</m>:<md>
                     <mrow>\frac{3}{p-2}+\frac{5}{p+2}\amp=\frac{12}{p^2-4}</mrow>
                     <mrow>\frac{3}{p-2}+\frac{5}{p+2}\amp=\frac{12}{(p+2)(p-2)}</mrow>
-                    <mrow>\highlight{(p+2)(p-2)\cdot}(\frac{3}{p-2}+\frac{5}{p+2})\amp=\highlight{(p+2)(p-2)\cdot}\frac{12}{(p+2)(p-2)}</mrow>
+                    <mrow>\multiplyleft{(p+2)(p-2)}(\frac{3}{p-2}+\frac{5}{p+2})\amp=\multiplyleft{(p+2)(p-2)}\frac{12}{(p+2)(p-2)}</mrow>
                     <mrow>(p+2)(p-2)\cdot\frac{3}{p-2}+(p+2)(p-2)\cdot\frac{5}{p+2}\amp=(p+2)(p-2)\cdot\frac{12}{(p+2)(p-2)}</mrow>
                     <mrow>3(p+2)+5(p-2)\amp=12</mrow>
                     <mrow>3p+6+5p-10\amp=12</mrow>
@@ -145,7 +145,7 @@
             <solution>
                 <p>In this equation, the domain condition is <m>R\ne0</m>. The common denominator is <m>R R_1 R_2</m>. We will multiply both sides of the equation by <m>R R_1 R_2</m>:<md>
                     <mrow>\frac{1}{R}\amp=\frac{1}{R_1}+\frac{1}{R_2}</mrow>
-                    <mrow>\highlight{R R_1 R_2\cdot}\frac{1}{R}\amp=\highlight{R R_1 R_2\cdot}(\frac{1}{R_1}+\frac{1}{R_2})</mrow>
+                    <mrow>\multiplyleft{R R_1 R_2}\frac{1}{R}\amp=\multiplyleft{R R_1 R_2}(\frac{1}{R_1}+\frac{1}{R_2})</mrow>
                     <mrow>R_1 R_2\amp=R R_1 R_2\cdot\frac{1}{R_1}+R R_1 R_2\cdot\frac{1}{R_2}</mrow>
                     <mrow>R_1 R_2\amp=R R_2 + R R_1</mrow>
                     <mrow>R_1 R_2\amp=R(R_2+R_1)</mrow>
@@ -162,9 +162,9 @@
             <solution>
                 <p>The common denominator is <m>x_2-x_1</m>. We will multiply both sides of the equation by <m>x_2-x_1</m>:<md>
                     <mrow>m=\frac{y_2-y_1}{x_2-x_1}</mrow>
-                    <mrow>\highlight{(x_2-x_1)\cdot}m=\highlight{(x_2-x_1)\cdot}\frac{y_2-y_1}{x_2-x_1}</mrow>
+                    <mrow>\multiplyleft{(x_2-x_1)}m=\multiplyleft{(x_2-x_1)}\frac{y_2-y_1}{x_2-x_1}</mrow>
                     <mrow>m x_2-m x_1\amp=y_2-y_1</mrow>
-                    <mrow>m x_2-m x_1\highlight{-m x_2}\amp=y_2-y_1\highlight{-m x_2}</mrow>
+                    <mrow>m x_2-m x_1\subtractright{m x_2}\amp=y_2-y_1\subtractright{m x_2}</mrow>
                     <mrow>-m x_1\amp=y_2-y_1-m x_2</mrow>
                     <mrow>\frac{-m x_1}{-m}\amp=\frac{y_2-y_1-m x_2}{-m}</mrow>
                     <mrow>x_1\amp=-\frac{y_2-y_1-m x_2}{m}</mrow>

--- a/src/section-solving-system-equations-by-graphing.mbx
+++ b/src/section-solving-system-equations-by-graphing.mbx
@@ -164,13 +164,13 @@
             <solution>
                 <p>Both lines are given in standard form. We learned that it's easier to graph standard-form equations by their <m>x</m>- and <m>y</m>-intercepts. However, that method would not accurately locate points on the lines, making it difficult to locate the intersection. This is why we need to change both lines to slope-intercept form, and then graph them by slope triangles, as in the last two examples.<md>
                     <mrow>x-3y\amp=-12</mrow>
-                    <mrow>x-3y\highlight{-x}\amp=-12\highlight{-x}</mrow>
+                    <mrow>x-3y\subtractright{x}\amp=-12\subtractright{x}</mrow>
                     <mrow>-3y\amp=-x-12</mrow>
                     <mrow>\frac{-3y}{-3}\amp=\frac{-x}{-3}+\frac{-12}{-3}</mrow>
                     <mrow>y\amp=\frac{1}{3}x+4</mrow>
                 </md><md>
                     <mrow>2x+3y\amp=3</mrow>
-                    <mrow>2x+3y\highlight{-2x}\amp=3\highlight{-2x}</mrow>
+                    <mrow>2x+3y\subtractright{2x}\amp=3\subtractright{2x}</mrow>
                     <mrow>3y\amp=-2x+3</mrow>
                     <mrow>\frac{3y}{3}\amp=\frac{-2x}{3}+\frac{3}{3}</mrow>
                     <mrow>y\amp=-\frac{2}{3}x+1</mrow>
@@ -361,7 +361,7 @@
 
         <p>We will change the equation <m>2x-y=4</m> into slope-intercept form:<md>
             <mrow>2x-y\amp=4</mrow>
-            <mrow>2x-y\highlight{-2x}\amp=4\highlight{-2x}</mrow>
+            <mrow>2x-y\subtractright{2x}\amp=4\subtractright{2x}</mrow>
             <mrow>-y\amp=-2x+4</mrow>
             <mrow>(-1)\cdot(-y)\amp=(-1)\cdot(-2x+4)</mrow>
             <mrow>y\amp=2x-4</mrow>

--- a/src/section-solving-system-equations-by-substitution.mbx
+++ b/src/section-solving-system-equations-by-substitution.mbx
@@ -78,14 +78,14 @@
                         \right.
                     </mrow></md>Next, to use substitution, we need to solve for <m>x</m> or <m>y</m> in the first equation <m>x+y=115</m>. Either choice will help us solve the system. We will solve for <m>y</m> in this example:<md>
                     <mrow>x+y\amp=115</mrow>
-                    <mrow>x+y\highlight{-x}\amp=115\highlight{-x}</mrow>
+                    <mrow>x+y\subtractright{x}\amp=115\subtractright{x}</mrow>
                     <mrow>y\amp=-x+115</mrow>
                 </md>Next, we substitute <m>y=-x+115</m> into the second equation <m>3.5x+1.5y=332.5</m>, and we have:<md>
                     <mrow>3.5x+1.5y\amp=332.5</mrow>
                     <mrow>3.5x+1.5(-x+115)\amp=332.5</mrow>
                     <mrow>3.5x-1.5x+172.5\amp=332.5</mrow>
                     <mrow>2x+172.5\amp=332.5</mrow>
-                    <mrow>2x+172.5\highlight{-172.5}\amp=332.5\highlight{-172.5}</mrow>
+                    <mrow>2x+172.5\subtractright{172.5}\amp=332.5\subtractright{172.5}</mrow>
                     <mrow>2x\amp=160</mrow>
                     <mrow>x\amp=80</mrow>
                 </md>Finally, we substitute <x>x=80</x> into <m>y=-x+115</m>, and we have:<md>
@@ -124,7 +124,7 @@
             <solution>
                 <p>To use substitution, we need to solve for <m>x</m> or <m>y</m> in one of the equations. Let's solve for <m>y</m> in the first equation:<md>
                     <mrow>-x+2y\amp=11</mrow>
-                    <mrow>-x+2y\highlight{+x}\amp=11\highlight{+x}</mrow>
+                    <mrow>-x+2y\addright{x}\amp=11\addright{x}</mrow>
                     <mrow>2y\amp=x+11</mrow>
                     <mrow>\frac{2y}{2}\amp=\frac{x}{2}+\frac{11}{2}</mrow>
                     <mrow>y\amp=\frac{1}{2}x+\frac{11}{2}</mrow>
@@ -132,7 +132,7 @@
 
                 <p>Notice that the coefficient of <m>x</m> in <m>-x+2y=11</m> is <m>-1</m>. When we multiply all terms in an equation by <m>-1</m>, we would not introduce fractions. Let's solve for <m>x</m> in <m>-x+2y=11</m> instead:<md>
                     <mrow>-x+2y\amp=11</mrow>
-                    <mrow>-x+2y\highlight{-2y}\amp=11\highlight{-2y}</mrow>
+                    <mrow>-x+2y\subtractright{2y}\amp=11\subtractright{2y}</mrow>
                     <mrow>-x\amp=-2y+11</mrow>
                     <mrow>(-1)\cdot(-x)\amp=(-1)\cdot(-2y+11)</mrow>
                     <mrow>x\amp=2y-11</mrow>
@@ -176,7 +176,7 @@
 
                 <p>Since <m>2=3</m> is false, this system has no solution. This implies those two lines are parallel. We can verify this by changing <m>4x-2y=3</m> into slope-intercept form:<md>
                     <mrow>4x-2y\amp=3</mrow>
-                    <mrow>4x-2y\highlight{-4x}\amp=3\highlight{-4x}</mrow>
+                    <mrow>4x-2y\subtractright{4x}\amp=3\subtractright{4x}</mrow>
                     <mrow>-2y\amp=-4x+3</mrow>
                     <mrow>\frac{-2y}{-2}\amp=\frac{-4x}{-2}+\frac{3}{-2}</mrow>
                     <mrow>y\amp=2x-\frac{3}{2}</mrow>
@@ -216,7 +216,7 @@
 
                 <p>Since <m>2=2</m> is true, this system has infinitely many solutions. This implies those two lines are actually the same line (or they overlap each other). We can verify this by changing <m>4x-2y=2</m> into slope-intercept form:<md>
                     <mrow>4x-2y\amp=2</mrow>
-                    <mrow>4x-2y\highlight{-4x}\amp=2\highlight{-4x}</mrow>
+                    <mrow>4x-2y\subtractright{4x}\amp=2\subtractright{4x}</mrow>
                     <mrow>-2y\amp=-4x+2</mrow>
                     <mrow>\frac{-2y}{-2}\amp=\frac{-4x}{-2}+\frac{2}{-2}</mrow>
                     <mrow>y\amp=2x-1</mrow>

--- a/src/section-special-solution-sets.mbx
+++ b/src/section-special-solution-sets.mbx
@@ -44,7 +44,7 @@
 
             <p>To solve this equation, we need to move <m>x</m> terms to one side of the equal sign:<md>
                 <mrow>x\amp=x+1</mrow>
-                <mrow>x\highlight{{}-x}\amp=x+1\highlight{{}-x}</mrow>
+                <mrow>x\subtractright{x}\amp=x+1\subtractright{x}</mrow>
                 <mrow>0\amp=1</mrow>
             </md></p>
 
@@ -58,7 +58,7 @@
 
             <p>We will move <m>x</m> terms to one side of the equal sign:<md>
                 <mrow>x\amp=x</mrow>
-                <mrow>x\highlight{{}-x}\amp=x\highlight{{}-x}</mrow>
+                <mrow>x\subtractright{x}\amp=x\subtractright{x}</mrow>
                 <mrow>0\amp=0</mrow>
             </md></p>
 
@@ -85,11 +85,11 @@
 
             <p>Solution:<md>
                 <mrow>\frac{2}{3}(a+1)-\frac{5}{6}\amp=\frac{2}{3}a</mrow>
-                <mrow>\highlight{6\cdot{}}\frac{2}{3}(a+1)-\highlight{6\cdot{}}\frac{5}{6}\amp=\highlight{6\cdot{}}\frac{2}{3}a</mrow>
+                <mrow>\multiplyleft{6}\frac{2}{3}(a+1)-\multiplyleft{6}\frac{5}{6}\amp=\multiplyleft{6}\frac{2}{3}a</mrow>
                 <mrow>4(a+1)-5\amp=4a</mrow>
                 <mrow>4a+4-5\amp=4a</mrow>
                 <mrow>4a-1\amp=4a</mrow>
-                <mrow>4a-1\highlight{{}-4a}\amp=4a\highlight{{}-4a}</mrow>
+                <mrow>4a-1\subtractright{4a}\amp=4a\subtractright{4a}</mrow>
                 <mrow>-1\amp=0</mrow>
             </md></p>
 
@@ -142,7 +142,7 @@
 
             <p>To solve this inequality, we need to move <m>x</m> terms to one side of the inequality sign:<md>
                 <mrow>x\amp\gt x+1</mrow>
-                <mrow>x\highlight{{}-x}\amp\gt x+1\highlight{{}-x}</mrow>
+                <mrow>x\subtractright{x}\amp\gt x+1\subtractright{x}</mrow>
                 <mrow>0\amp\gt 1</mrow>
             </md></p>
 
@@ -156,7 +156,7 @@
 
             <p>To solve this inequality, we need to move <m>x</m> terms to one side of the inequality sign:<md>
                 <mrow>x\amp\le x</mrow>
-                <mrow>x\highlight{{}-x}\amp\le x\highlight{{}-x}</mrow>
+                <mrow>x\subtractright{x}\amp\le x\subtractright{x}</mrow>
                 <mrow>0\amp\le 0</mrow>
             </md></p>
 

--- a/src/section-standard-form.mbx
+++ b/src/section-standard-form.mbx
@@ -157,7 +157,7 @@
         <p>What is the slope of the linear relationship? It's not immediately visible since <m>m</m> is not part of the standard form equation. But we can use algebra to isolate <m>y</m>:<md>
             <mrow>20x+100y\amp=10000</mrow>
             <mrow>100y\amp=\highlight{-20x}+10000</mrow>
-            <mrow>y\amp=\frac{-20x+10000}{\highlight{100}}</mrow>
+            <mrow>y\amp=\divideunder{-20x+10000}{100}</mrow>
             <mrow>y\amp=\frac{-20x}{100}+\frac{10000}{100}</mrow>
             <mrow>y\amp=-\frac{1}{5}x+100\text{.}</mrow>
         </md>And we see that the slope is <m>-\frac{1}{5}</m>. OK, what units are on that slope? As always, the units on slope are <m>\frac{y\text{-unit}}{x\text{-unit}}</m>. In this case that's <m>\frac{\text{person}}{\text{person}}</m>, which sounds a little weird and seems like it should be simplified away to unitless. But this slope of <m>-\frac{1}{5}\frac{\text{person}}{\text{person}}</m> is saying that for every one extra person who donates <m>\$20</m>, you only need <m>\frac{1}{5}</m> fewer people donating <m>\$100</m> to still reach your goal.</p>
@@ -166,9 +166,9 @@
 
         <p>What does a graph for this line look like? We've already converted into slope-intercept form, and we could use that to make the graph. But when given a line in standard form, there is another approach that is often used. Returning to <me>20x+100y=10000\text{,}</me> let's calculate the <m>y</m>-intercept and the <m>x</m>-intercept. Recall that these are <em>points</em> where the line crosses the <m>y</m>-axis and <m>x</m>-axis. To be on the <m>y</m>-axis means that <m>x=0</m>, and to be on the <m>x</m>-axis means that <m>y=0</m>. All these zeros make the resulting algebra easy to solve:<md>
             <mrow>20x+100y\amp=10000\amp20x+100y\amp=10000</mrow>
-            <mrow>20(\highlight{0})+100y\amp=10000\amp20x+100(\highlight{0})\amp=10000</mrow>
+            <mrow>20(\substitute{0})+100y\amp=10000\amp20x+100(\substitute{0})\amp=10000</mrow>
             <mrow>100y\amp=10000\amp20x\amp=10000</mrow>
-            <mrow>y\amp=\frac{10000}{\highlight{100}}\amp x\amp=\frac{10000}{\highlight{20}}</mrow>
+            <mrow>y\amp=\divideunder{10000}{100}\amp x\amp=\divideunder{10000}{20}</mrow>
             <mrow>y\amp=100\amp x\amp=500</mrow>
         </md></p>
 
@@ -218,10 +218,10 @@
 
             <md>
                 <mrow>y\amp=-32x+1200</mrow>
-                <mrow>\highlight{0}\amp=-32x+1200</mrow>
-                <mrow>0\highlight{{}-1200}\amp=-32x</mrow>
+                <mrow>\substitute{0}\amp=-32x+1200</mrow>
+                <mrow>0\subtractright{1200}\amp=-32x</mrow>
                 <mrow>-1200\amp=-32x</mrow>
-                <mrow>\frac{-1200}{\highlight{-32}}\amp=x</mrow>
+                <mrow>\divideunder{-1200}{-32}\amp=x</mrow>
                 <mrow>37.5\amp=x</mrow>
             </md></p>
 
@@ -231,7 +231,7 @@
 
             <md>
                 <mrow>y\amp=-32x+1200</mrow>
-                <mrow>y\amp=-32(\highlight{0})+1200</mrow>
+                <mrow>y\amp=-32(\substitute{0})+1200</mrow>
                 <mrow>y\amp=1200</mrow>
             </md></p>
 
@@ -284,14 +284,14 @@
 
                 <p>Next, we calculate the line's <m>x</m>-intercept by substituting <m>y=0</m> into the equation<md>
                     <mrow>2x-3y\amp=-6</mrow>
-                    <mrow>2x-3(\highlight{0})\amp=-6</mrow>
+                    <mrow>2x-3(\substitute{0})\amp=-6</mrow>
                     <mrow>2x\amp=-6</mrow>
                     <mrow>x\amp=-3</mrow>
                 </md>So the line's <m>x</m>-intercept is <m>(-3,0)\text{.}</m></p>
 
                 <p>Similarly, we substitute <m>x=0</m> into the equation to calculate the <m>y</m>-intercept:<md>
                     <mrow>2x-3y\amp=-6</mrow>
-                    <mrow>2(\highlight{0})-3y\amp=-6</mrow>
+                    <mrow>2(\substitute{0})-3y\amp=-6</mrow>
                     <mrow>-3y\amp=-6</mrow>
                     <mrow>y\amp=2</mrow>
                 </md>So the line's <m>y</m>-intercept is <m>(0,2)</m>. Now we can complete the table:</p>
@@ -391,15 +391,15 @@
                 <solution>
                     <p>To find the <m>x</m>-intercept:<md>
                         <mrow>2x+4.3y\amp=\frac{1000}{99}</mrow>
-                        <mrow>2x+4.3(\highlight{0})\amp=\frac{1000}{99}</mrow>
+                        <mrow>2x+4.3(\substitute{0})\amp=\frac{1000}{99}</mrow>
                         <mrow>2x\amp=\frac{1000}{99}</mrow>
                         <mrow>x\amp=\frac{500}{99}</mrow>
                     </md>So the <m>x</m>-intercept is at <m>\left(\frac{500}{99},0\right)</m>.</p>
                     <p>To find the <m>y</m>-intercept:<md>
                         <mrow>2x+4.3y\amp=\frac{1000}{99}</mrow>
-                        <mrow>2(\highlight{0})+4.3y\amp=\frac{1000}{99}</mrow>
+                        <mrow>2(\substitute{0})+4.3y\amp=\frac{1000}{99}</mrow>
                         <mrow>4.3y\amp=\frac{1000}{99}</mrow>
-                        <mrow>y\amp=\highlight{\frac{1}{4.3}}\frac{1000}{99}</mrow>
+                        <mrow>y\amp=\multiplyleft{\frac{1}{4.3}}\frac{1000}{99}</mrow>
                         <mrow>y\amp\approx2.349\ldots</mrow>
                     </md>So the <m>y</m>-intercept is at about <m>(0,2.349)</m>.</p>
                     <p>Since we have the <m>x</m>- and <m>y</m>-intercepts, we can calulate the slope: <me>m\approx-\frac{2.349}{\frac{500}{99}}=-\frac{2.349\cdot99}{500}\approx-0.4561\text{.}</me></p>
@@ -430,9 +430,9 @@
                 <p>Since a line in slope-intercept form looks like <m>y=\ldots</m>, we will solve for <m>y</m> in <m>2x-3y=-6\text{:}</m>
                 <md>
                     <mrow>2x-3y\amp=-6</mrow>
-                    <mrow>-3y\amp=-6\highlight{{}-2x}</mrow>
+                    <mrow>-3y\amp=-6\subtractright{2x}</mrow>
                     <mrow>-3y\amp=-2x-6</mrow>
-                    <mrow>y\amp=\frac{-2x-6}{\highlight{-3}}</mrow>
+                    <mrow>y\amp=\divideunder{-2x-6}{-3}</mrow>
                     <mrow>y\amp=\frac{-2x}{-3}-\frac{6}{-3}</mrow>
                     <mrow>y\amp=\frac{2}{3}x+2</mrow>
                 </md></p>
@@ -484,7 +484,7 @@
 
                 <p>Trying to find the <m>x</m>-intercept:<md>
                     <mrow>2x-3y\amp=0</mrow>
-                    <mrow>2x-3(\highlight{0})\amp=0</mrow>
+                    <mrow>2x-3(\substitute{0})\amp=0</mrow>
                     <mrow>2x\amp=0</mrow>
                     <mrow>x\amp=0</mrow>
                 </md>So the line's <m>x</m>-intercept is at <m>(0,0)\text{,}</m> at the origin.</p>
@@ -493,16 +493,16 @@
 
                 <p>Trying to find the <m>y</m>-intercept:<md>
                     <mrow>2x-3y\amp=0</mrow>
-                    <mrow>2(\highlight{0})-3y\amp=0</mrow>
+                    <mrow>2(\substitute{0})-3y\amp=0</mrow>
                     <mrow>-3y\amp=0</mrow>
                     <mrow>y\amp=0</mrow>
                 </md>So the line's <m>y</m>-intercept is also at <m>(0,0)</m>.</p>
 
                 <p>Since both intercepts are the same point, there is no way to use the intercepts alone to graph this line. So what can be done? Several approaches are out there, but one is to convert the line equation into slope-intercept form:<md>
                     <mrow>2x-3y\amp=0</mrow>
-                    <mrow>-3y\amp=0\highlight{{}-2x}</mrow>
+                    <mrow>-3y\amp=0\subtractright{2x}</mrow>
                     <mrow>-3y\amp=-2x</mrow>
-                    <mrow>y\amp=\frac{-2x}{\highlight{-3}}</mrow>
+                    <mrow>y\amp=\divideunder{-2x}{-3}</mrow>
                     <mrow>y\amp=\frac{2}{3}x</mrow>
                 </md></p>
 
@@ -547,10 +547,10 @@
             <solution>
                 <p>Once we subtract <m>\frac{2}{3}x</m> on both sides of the equation, we have<me>-\frac{2}{3}x+y=2</me>Technically, this equation is already in standard form <m>Ax+By=C\text{.}</m> However, you might like to end up with an equation that has no fractions, and so you can take some extra steps.<md>
                     <mrow>y\amp=\frac{2}{3}x+2</mrow>
-                    <mrow>y\highlight{{}-\frac{2}{3}x}\amp=2</mrow>
+                    <mrow>y\subtractright{\frac{2}{3}x}\amp=2</mrow>
                     <mrow>-\frac{2}{3}x+y\amp=2</mrow>
                     <intertext>This is in standard form, but we keep going to clear away the fraction.</intertext>
-                    <mrow>\highlight{3\cdot{}}\left(-\frac{2}{3}x+y\right)\amp=\highlight{3\cdot{}}2</mrow>
+                    <mrow>\multiplyleft{3}\left(-\frac{2}{3}x+y\right)\amp=\multiplyleft{3}2</mrow>
                     <mrow>-2x+3y\amp=6\text{.}</mrow>
                 </md></p>
             </solution>

--- a/src/section-summary-of-graphing-lines.mbx
+++ b/src/section-summary-of-graphing-lines.mbx
@@ -68,27 +68,27 @@
                         </row>
                         <row>
                             <cell><m>\highlight{-2}</m></cell>
-                            <cell><m>y=-2(\highlight{-2})+1=5</m></cell>
+                            <cell><m>y=-2(\substitute{-2})+1=5</m></cell>
                             <cell><m>(-2,5)</m></cell>
                         </row>
                         <row>
                             <cell><m>\highlight{-1}</m></cell>
-                            <cell><m>y=-2(\highlight{-1})+1=3</m></cell>
+                            <cell><m>y=-2(\substitute{-1})+1=3</m></cell>
                             <cell><m>(-1,3)</m></cell>
                         </row>
                         <row>
                             <cell><m>\highlight{0}</m></cell>
-                            <cell><m>y=-2(\highlight{0})+1=1</m></cell>
+                            <cell><m>y=-2(\substitute{0})+1=1</m></cell>
                             <cell><m>(0,1)</m></cell>
                         </row>
                         <row>
                             <cell><m>\highlight{1}</m></cell>
-                            <cell><m>y=-2(\highlight{1})+1=-1</m></cell>
+                            <cell><m>y=-2(\substitute{1})+1=-1</m></cell>
                             <cell><m>(1,-1)</m></cell>
                         </row>
                         <row>
                             <cell><m>\highlight{2}</m></cell>
-                            <cell><m>y=-2(\highlight{2})+1=-3</m></cell>
+                            <cell><m>y=-2(\substitute{2})+1=-3</m></cell>
                             <cell><m>(2,-3)</m></cell>
                         </row>
                     </tabular>
@@ -182,10 +182,10 @@
                     <title>Set <m>y=0</m>.</title>
                     <p><md>
                         <mrow>y\amp=-2x+1</mrow>
-                        <mrow>\highlight{0}\amp=-2x+1</mrow>
-                        <mrow>0\highlight{{}-1}\amp=-2x</mrow>
+                        <mrow>\substitute{0}\amp=-2x+1</mrow>
+                        <mrow>0\subtractright{1}\amp=-2x</mrow>
                         <mrow>-1\amp=-2x</mrow>
-                        <mrow>\frac{-1}{\highlight{-2}}\amp=x</mrow>
+                        <mrow>\divideunder{-1}{-2}\amp=x</mrow>
                         <mrow>\frac{1}{2}\amp=x</mrow>
                     </md></p>
                 </paragraphs>
@@ -261,11 +261,11 @@
 
             <p><md>
                 <mrow>3x+4y\amp=12</mrow>
-                <mrow>3(\highlight{-2})+4y\amp=12</mrow>
+                <mrow>3(\substitute{-2})+4y\amp=12</mrow>
                 <mrow>-6+4y\amp=12</mrow>
-                <mrow>4y\amp=12\highlight{{}+6}</mrow>
+                <mrow>4y\amp=12\addright{6}</mrow>
                 <mrow>4y\amp=18</mrow>
-                <mrow>y\amp=\frac{18}{\highlight{4}}</mrow>
+                <mrow>y\amp=\divideunder{18}{4}</mrow>
                 <mrow>y\amp=\frac{9}{2}</mrow>
             </md></p>
     
@@ -307,17 +307,17 @@
             <sidebyside valign="top" widths="47% 47%">
                 <p>We have to calculate the line's <m>x</m>-intercept by substituting <m>y=0</m> into the equation:<md>
                     <mrow>3x+4y\amp=12</mrow>
-                    <mrow>3x+4(\highlight{0})\amp=12</mrow>
+                    <mrow>3x+4(\substitute{0})\amp=12</mrow>
                     <mrow>3x\amp=12</mrow>
-                    <mrow>x\amp=\frac{12}{\highlight{3}}</mrow>
+                    <mrow>x\amp=\divideunder{12}{3}</mrow>
                     <mrow>x\amp=4</mrow>
                 </md></p>
 
                 <p>And similarly for the <m>y</m>-intercept:<md>
                     <mrow>3x+4y\amp=12</mrow>
-                    <mrow>3(\highlight{0})+4y\amp=12</mrow>
+                    <mrow>3(\substitute{0})+4y\amp=12</mrow>
                     <mrow>4y\amp=12</mrow>
-                    <mrow>y\amp=\frac{12}{\highlight{4}}</mrow>
+                    <mrow>y\amp=\divideunder{12}{4}</mrow>
                     <mrow>y\amp=3</mrow>
                 </md></p>
             </sidebyside>
@@ -377,9 +377,9 @@
         <example>
             <p>We can always rearrange <m>3x+4y=12</m> into <xref ref="equation-slope-intercept-form">slope-intercept form</xref>, and then graph it with the slope triangle method:<md>
                 <mrow>3x+4y\amp=12</mrow>
-                <mrow>4y\amp=12\highlight{{}-3x}</mrow>
+                <mrow>4y\amp=12\subtractright{3x}</mrow>
                 <mrow>4y\amp=-3x+12</mrow>
-                <mrow>y\amp=\frac{-3x+12}{\highlight{4}}</mrow>
+                <mrow>y\amp=\divideunder{-3x+12}{4}</mrow>
                 <mrow>y\amp=-\frac{3}{4}x+3</mrow>
             </md></p>
     


### PR DESCRIPTION
I'm going to leave this here for a few days so you can all see the new macros for highlighting changes in equations. I ended up not able to use `\multiply` and `\divide` because those already have definitions in LaTeX. So the new macros are `\substitute`, `\addright`, `\addleft`, `\subtractright`, `\multiplyleft`, `\multiplyright`, and `\divideunder`.

The multiplication macros can take an optional argument for the multiplication symbol used. And `\divideunder` takes two arguments: numerator then denominator (which is the part that gets highlighted).