### PR TITLE
bringing in Math95 library problems

### DIFF
--- a/src/section-exponent-rules-and-scientific-notation.ptx
+++ b/src/section-exponent-rules-and-scientific-notation.ptx
@@ -1865,6 +1865,36 @@
                 <webwork source="BasicAlgebra/Exponents/negExp10.pg" />
             </exercise>
             <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents1.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents1.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents2.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents2.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents3.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents3.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents4.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents4.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents5.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/NegativeExponents/NegativeExponents5.pg" />
+            </exercise>
+            <exercise>
                 <webwork source="BasicAlgebra/Exponents/negExp15.pg" />
             </exercise>
             <exercise>
@@ -2202,7 +2232,6 @@
             </exercise>
 
         </exercisegroup>
-
     </exercises>
 
 

--- a/src/section-function-basics.ptx
+++ b/src/section-function-basics.ptx
@@ -1137,7 +1137,7 @@
     <exercises>
         <exercisegroup cols="2">
             <introduction>
-                <p>Evaluate a function formula.</p>
+                <p>Evaluate a function using its formula.</p>
             </introduction>
             <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/EvaluateFunction10.pg" />
@@ -1234,6 +1234,48 @@
             </exercise>
             <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/EvaluateFunction140.pg" />
+            </exercise>
+        </exercisegroup>
+
+        <exercisegroup cols="2">
+            <introduction>
+                <p>Solve an Equation with Function Notation</p>
+            </introduction>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation30.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation30.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve30.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve30.pg" />
             </exercise>
         </exercisegroup>
 
@@ -1272,6 +1314,24 @@
                 <p>Use a graph to understand a function.</p>
             </introduction>
             <exercise>
+                <webwork source="Math95/Functions/Functions12.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions12.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions13.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions13.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions14.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions14.pg" />
+            </exercise>
+            <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/FunctionValuesByGraph10.pg" />
             </exercise>
             <exercise>
@@ -1293,65 +1353,102 @@
 
         <exercisegroup>
             <introduction>
-                <p>Functions and Points on a Table</p>
+                <p>Use a table to understand a function.</p>
             </introduction>
+            <exercise>
+                <webwork source="Math95/Functions/Functions15.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions15.pg" />
+            </exercise>
             <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/DataFromTable10.pg" />
             </exercise>
             <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/DataFromTable10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Connally3-2-1-25-Input-and-output.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/FunctionTables10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/FunctionTables20.pg" />
             </exercise>
         </exercisegroup>
 
-        <exercisegroup cols="2">
+        <exercisegroup>
             <introduction>
-                <p>Solve an Equation with Function Notation</p>
+                <p>Translate between different representations of a function.</p>
             </introduction>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation10.pg" />
+                <webwork source="Math95/Functions/Functions16.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation10.pg" />
+                <webwork source="Math95/Functions/Functions16.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation20.pg" />
+                <webwork source="Math95/Functions/Functions17.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation20.pg" />
+                <webwork source="Math95/Functions/Functions17.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation30.pg" />
+                <webwork source="Math95/Functions/Functions18.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionEquation30.pg" />
+                <webwork source="Math95/Functions/Functions18.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions19.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/Functions/Functions19.pg" />
             </exercise>
         </exercisegroup>
 
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve10.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve10.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve20.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve20.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve30.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/EvaluateAndSolve30.pg" />
-        </exercise>
 
-
-
-        <exercisegroup cols="2">
+        <exercisegroup>
             <introduction>
                 <p>Identify meanings of quantites in context.</p>
             </introduction>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext20.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext30.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext30.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext40.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext40.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionValuesByGraph45.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="BasicAlgebra/FunctionBasics/FunctionValuesByGraph45.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/FunctionApplication10.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="CollegeAlgebra/FunctionBasics/FunctionApplication10.pg" />
+            </exercise>
             <exercise>
                 <webwork source="BasicAlgebra/FunctionBasics/Functions150.pg" />
             </exercise>
@@ -1359,72 +1456,27 @@
                 <webwork source="BasicAlgebra/FunctionBasics/Functions160.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext10.pg" />
+                <webwork source="Math95/LinearFunctions/LinearFunctions5.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext10.pg" />
+                <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q19.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext20.pg" />
+                <webwork source="Math95/LinearFunctions/LinearFunctions6.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext20.pg" />
+                <webwork source="Math95/LinearFunctions/LinearFunctions7.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext30.pg" />
+                <webwork source="CollegeAlgebra/FunctionBasics/PositionVelocity10.pg" />
             </exercise>
             <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext30.pg" />
+                <webwork source="CollegeAlgebra/FunctionBasics/PositionVelocity10.pg" />
             </exercise>
-            <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext40.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionInContext40.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionValuesByGraph45.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="BasicAlgebra/FunctionBasics/FunctionValuesByGraph45.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="CollegeAlgebra/FunctionBasics/FunctionApplication10.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="CollegeAlgebra/FunctionBasics/FunctionApplication10.pg" />
-            </exercise>
-        </exercisegroup>
-
-        <exercise>
-            <webwork source="Library/LoyolaChicago/Precalc/Chap2Sec1/Connally3-2-1-25-Input-and-output.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="Library/LoyolaChicago/Precalc/Chap1Sec1/Q19.pg" />
-        </exercise>
-
-
-        <exercisegroup>
-            <introduction>
-                <p>Make a table to plot a function.</p>
-            </introduction>
-            <exercise>
-                <webwork source="CollegeAlgebra/FunctionBasics/FunctionTables10.pg" />
-            </exercise>
-            <exercise>
-                <webwork source="CollegeAlgebra/FunctionBasics/FunctionTables20.pg" />
-            </exercise>
-
         </exercisegroup>
 
 
 
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/PositionVelocity10.pg" />
-        </exercise>
-        <exercise>
-            <webwork source="CollegeAlgebra/FunctionBasics/PositionVelocity10.pg" />
-        </exercise>
 
         <!-- Uses ColumnTable macro which is not yet PTX compatible -->
         <!--
@@ -1448,6 +1500,9 @@
                 <p>Give your function a name. Write the symbol(s) that you would use to represent input. Write the symbol(s) that you would use to represent output.</p>
             </statement>
         </exercise>
+
+
+
 
 
    </exercises>

--- a/src/section-slope.ptx
+++ b/src/section-slope.ptx
@@ -708,6 +708,18 @@
             <exercise>
                 <webwork source="BasicAlgebra/GraphingPointsAndLines/FindSlopeByGraph60.pg" />
             </exercise>
+            <exercise>
+                <webwork source="Math95/LinearEquations/LinearEquations3.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearEquations/LinearEquations3.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearEquations/LinearEquations4.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearEquations/LinearEquations4.pg" />
+            </exercise>
         </exercisegroup>
         <exercisegroup cols="2">
             <introduction>
@@ -768,6 +780,9 @@
                 <webwork source="BasicAlgebra/SlopeAndY-InterceptCalculations/SlopeFormula90.pg" />
             </exercise>
         </exercisegroup>
+
+
+
     </exercises>
 
 </section>

--- a/src/section-solving-multistep-linear-equations-and-inequalities.ptx
+++ b/src/section-solving-multistep-linear-equations-and-inequalities.ptx
@@ -1127,6 +1127,20 @@
             <exercise>
                 <webwork source="BasicAlgebra/LinearInequalities/InequalityWordProblem10.pg" />
             </exercise>
+            <exercise>
+                <webwork source="Math95/LinearInequalities/LinearInequalities8.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearInequalities/LinearInequalities8.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearInequalities/LinearInequalities9.pg" />
+            </exercise>
+            <exercise>
+                <webwork source="Math95/LinearInequalities/LinearInequalities9.pg" />
+            </exercise>
         </exercisegroup>
+
+
     </exercises>
 </section>


### PR DESCRIPTION
I'm folding in Math95 library problems. I already have pasted them into my local section files, but I am only committing as I go through each section. I notice Ann just added some of these to the complex fractions section, and that is fine. When I get there I will compare to the ones I have pasted locally, and I may reorder.

Also, as I go, I am examining the code for these questions and making adjustments to make it behave better. Either with PTX layout concerns, or the answer input/checking for the WBWK code. So I will be getting to previously expressed concerns there.

BTW, do we have to stick with "complex fractions" as the name for these things? Seems confusing with complex numbers also under discussion. Not sure what is a good alternative...maybe "complicated fractions"? Or "fractions of fractions"? In person I say things like "triple-decker fraction" or a "fraction with four levels"...