### PR TITLE
edited for phrases with 'the function f(x)' or similar

### DIFF
--- a/src/section-graphing-quadratic-functions.ptx
+++ b/src/section-graphing-quadratic-functions.ptx
@@ -129,7 +129,7 @@
             <p>To graph a quadratic function using its key features, we will algebraically determine the following: whether the function opens upward or downward, the vertical intercept, the horizontal intercepts and the vertex. Then we will graph the points and connect them with a smooth curve.</p>
 
         <example><!--factors, two horizontal intercepts-->
-           <p>Graph the function <m>y=2x^2+10x+8</m> by algebraically determining its key features.</p>
+           <p>Graph the function for which <m>y=2x^2+10x+8</m> by algebraically determining its key features.</p>
 
             <p>To start, we'll note that this function will open upward, as the leading coefficient is the positive number <m>2</m>.</p>
 
@@ -233,7 +233,7 @@
         </example>
 
         <example><!-- requires QF, no horizontal intercepts -->
-            <p>Graph the function <m>y=-x^2+4x-5</m> by algebraically determining its key features.</p>
+            <p>Graph the function for which <m>y=-x^2+4x-5</m> by algebraically determining its key features.</p>
 
             <p>To start, we'll note that this function will open downward, as the leading coefficient is negative.</p>
 
@@ -521,7 +521,7 @@
 
         <example xml:id="example-remote-control-airplane-quadratic-application"> <!-- opens upward -->
             <statement>
-                <p>The owner of a remote-controlled airplane is going to do a stunt dive where the plane dives toward the ground and back up along a parabolic path. The height of the plane is given by the function <m>H(t)=0.7t^2-23t+200</m>, for <m>0 \le t \le 30</m>. The height is measured in feet and the time, <m>t</m>, is measured in seconds.
+                <p>The owner of a remote-controlled airplane is going to do a stunt dive where the plane dives toward the ground and back up along a parabolic path. The height of the plane is given by the function <m>H</m> where <m>H(t)=0.7t^2-23t+200</m>, for <m>0 \le t \le 30</m>. The height is measured in feet and the time, <m>t</m>, is measured in seconds.
                     <ol label="a.">
                         <li><p>Determine the starting height of the plane as the dive begins.</p></li>
                         <li><p>Determine the height of the plane after <m>5</m> seconds.</p></li>

--- a/src/section-graphs-and-vertex-form.ptx
+++ b/src/section-graphs-and-vertex-form.ptx
@@ -448,7 +448,7 @@
                 </figure>
             </sidebyside>
 
-        <p>Notice that the <m>x</m>-coordinate of the vertex has the opposite sign as the value in the function formula. On the other hand, the <m>y</m>-coordinate of the vertex has the same sign as the value in the function formula. Let's look at an example to understand why. We will substitute <m>x=2</m> in the function <m>r(x)</m> from <xref ref="figure-vertex-in-first-quadrant">Figure</xref>.<md>
+        <p>Notice that the <m>x</m>-coordinate of the vertex has the opposite sign as the value in the function formula. On the other hand, the <m>y</m>-coordinate of the vertex has the same sign as the value in the function formula. Let's look at an example to understand why. We will substitute <m>x=2</m> into <m>r(x)</m> from <xref ref="figure-vertex-in-first-quadrant">Figure</xref>.<md>
             <mrow>r(x)\amp=(x-2)^2+1</mrow>
             <mrow>r(\substitute{2})\amp=(\substitute{2}-2)^2+1</mrow>
             <mrow>\amp=(0)^2+1</mrow>
@@ -627,7 +627,7 @@
 
         <example>
             <statement>
-                <p>At the height of <m>90.2</m> feet above sea level, an object is launched at a vertical velocity of <m>14.4</m> feet per second. The object's height can be modeled by the function <m>h(t)=-16t^2+14.4t+90.2</m>, where <m>h(t)</m> represents the object's height in feet, and <m>t</m> represents time passed since the launch in seconds. When will the object reach its maximum height?</p>
+                <p>At the height of <m>90.2</m> feet above sea level, an object is launched at a vertical velocity of <m>14.4</m> feet per second. The object's height can be modeled by the function <m>h</m> where <m>h(t)=-16t^2+14.4t+90.2</m>, where <m>h(t)</m> represents the object's height in feet, and <m>t</m> represents time passed since the launch in seconds. When will the object reach its maximum height?</p>
 
                 <p>To find the object's maximum height, we need to locate the parabola's vertex. We will change the function from standard form to vertex form. In this example, it would be difficult to use the method of completing the square. We will use the vertex formula instead.</p>
 
@@ -695,7 +695,7 @@
                     <mrow>\amp=1562.5</mrow>
                 </md>The parabola's vertex is at <m>(7.5,1562.5)</m>. This implies Michael should raise the price per painting <m>7.5</m> times, or by <m>7.5\cdot2=15</m> dollars. This would make the price per painting <m>10+15=25</m> dollars,  and his annual income from paintings would become <dollar/><m>1562.50</m> by this math model.</p>
 
-                <p>With graphing technology, we can double check the maximum value of the function <m>f(x)=-10x^2+150x+1000</m>.</p>
+                <p>With graphing technology, we can double check the maximum value of the function <m>f</m> where <m>f(x)=-10x^2+150x+1000</m>.</p>
 
                 <figure>
                     <caption>Graph of <m>f(x)=-10x^2+150x+1000</m></caption>

--- a/src/section-introduction-to-absolute-value-functions.ptx
+++ b/src/section-introduction-to-absolute-value-functions.ptx
@@ -549,7 +549,7 @@
 
         <example>
             <statement>
-                <p>The function <m>D</m> defined by <m>D(T)=\abs{T-98.6}</m> represents the difference between a person's temperature, T, in Fahrenheit, and <quantity><mag>98.6</mag><unit base="fahrenheit" /></quantity>. A person's temperature is considered <q>normal</q> if <m>D(T)</m> is less than or equal to <m>0.5</m>. Use the function <m>D(T)</m> to evaluate each person's temperature.<ol label="a.">
+                <p>The function <m>D</m> defined by <m>D(T)=\abs{T-98.6}</m> represents the difference between a person's temperature, T, in Fahrenheit, and <quantity><mag>98.6</mag><unit base="fahrenheit" /></quantity>. A person's temperature is considered <q>normal</q> if <m>D(T)</m> is less than or equal to <m>0.5</m>. Use <m>D(T)</m> to evaluate each person's temperature.<ol label="a.">
                     <li><p>If a person has a temperature of <quantity><mag>98.3</mag><unit base="fahrenheit" /></quantity>, is that within normal range?</p></li>
                     <li><p>If a person has a temperature of <quantity><mag>99.3</mag><unit base="fahrenheit" /></quantity>, is that within normal range?</p></li>
                     <li><p>If a person has a temperature of <quantity><mag>97.3</mag><unit base="fahrenheit" /></quantity>, is that within normal range?</p></li>

--- a/src/section-introduction-to-functions.ptx
+++ b/src/section-introduction-to-functions.ptx
@@ -477,7 +477,7 @@
         <example xml:id="example-bees">
             <title>Functions in Graphical Form</title>
             <statement>
-                <p>A colony of bees settled in Ann's backyard in 2012. Let <m>B(x)</m> be the number of bees in the colony (in thousands) <m>x</m> months after April 1, 2012. A graph of the function <m>y=B(x)</m> is shown in <xref ref="figure-bees">Figure</xref>.</p>
+                <p>A colony of bees settled in Ann's backyard in 2012. Let <m>B(x)</m> be the number of bees in the colony (in thousands) <m>x</m> months after April 1, 2012. A graph of <m>y=B(x)</m> is shown in <xref ref="figure-bees">Figure</xref>.</p>
 
                 <sidebyside widths="47% 47%" margins="0%">
 

--- a/src/section-introduction-to-radical-functions.ptx
+++ b/src/section-introduction-to-radical-functions.ptx
@@ -243,7 +243,7 @@
 
         <example>
             <statement>
-                <p>Algebraically find the domain of the function <m>g(x)=\sqrt{2x-4}+1</m> and then find the range by making a graph.</p>
+                <p>Algebraically find the domain of the function <m>g</m> where <m>g(x)=\sqrt{2x-4}+1</m> and then find the range by making a graph.</p>
             </statement>
             <solution>
                 <p>Using <xref ref="fact-domain-of-square-root">Fact</xref> find the function's domain, we set the radicand greater than or equal to zero:<md>
@@ -277,7 +277,7 @@
 
         <example>
             <statement>
-                <p>Algebraically find the domain and graphically find the range of the function <m>h(x)=2-3\sqrt{8-5x}</m>.</p>
+                <p>Algebraically find the domain and graphically find the range of the function <m>h</m> where <m>h(x)=2-3\sqrt{8-5x}</m>.</p>
             </statement>
             <solution>
                 <p>To find the function's domain, we set the radicand to be greater than or equal to zero:</p>
@@ -322,7 +322,7 @@
                 </ol></p>
             </statement>
             <solution>
-                <p>With graphing technology, and after adjusting the window settings, we can see the graph of the function <m>t=\sqrt{\frac{d}{16}}</m> and some important points.</p>
+                <p>With graphing technology, and after adjusting the window settings, we can see the graph of <m>t=\sqrt{\frac{d}{16}}</m> and some important points.</p>
 
                 <figure>
                     <caption>Graph of <m>t=\sqrt{\frac{d}{16}}</m></caption>
@@ -682,8 +682,8 @@
         <example>
             <statement>
                 <p><ol label="a.">
-                    <li><p>Algebraically find the domain and graphically find the range of the function <m>g(x)=7-3\sqrt[4]{10-5x}</m>.</p></li>
-                    <li><p>Algebraically find the domain and graphically find the range of the function <m>h(x)=4\sqrt[5]{2x-5}+1</m>.</p></li>
+                    <li><p>Algebraically find the domain and graphically find the range of the function <m>g</m> where <m>g(x)=7-3\sqrt[4]{10-5x}</m>.</p></li>
+                    <li><p>Algebraically find the domain and graphically find the range of the function <m>h</m> where <m>h(x)=4\sqrt[5]{2x-5}+1</m>.</p></li>
                 </ol></p>
             </statement>
             <solution>
@@ -714,7 +714,7 @@
                         </figure>
                     </li>
                     <li>
-                        <p>First note that the index of the function <m>h(x)=4\sqrt[5]{2x-5}+1</m> is <m>5</m>. By <xref ref="fact-domain-of-odd-index-radical">Fact</xref>, the domain is <m>(-\infty,\infty)</m>.</p>
+                        <p>First note that the index of the function <m>h</m> for <m>h(x)=4\sqrt[5]{2x-5}+1</m> is <m>5</m>. By <xref ref="fact-domain-of-odd-index-radical">Fact</xref>, the domain is <m>(-\infty,\infty)</m>.</p>
                         
                         <p>To find the function's range, we use technology to graph the function. According to the graph, the function's range is also the set of all real numbers.</p>
                         <figure>

--- a/src/section-introduction-to-rational-functions.ptx
+++ b/src/section-introduction-to-rational-functions.ptx
@@ -231,7 +231,7 @@
 
         <example xml:id="example-introduction-to-rational-functions">
             <statement>
-                <p>Build a table and sketch the graph of the function <m>f(x)=\frac{1}{x-2}</m>. Find the function's domain and range.</p>
+                <p>Build a table and sketch the graph of the function <m>f</m> where <m>f(x)=\frac{1}{x-2}</m>. Find the function's domain and range.</p>
 
                 <p>Since <m>x=2</m> makes the denominator <m>0</m>, the function will be undefined where <m>x=2</m>. We'll start by choosing various <m>x</m>-values and plotting the associated points.</p>
                 
@@ -420,7 +420,7 @@
 <!-- 
         <example>
             <statement>
-                <p>Use technology to build a table and graph the function <m>f(x)=\frac{1}{x^2}</m>. Find the function's domain and range.</p>
+                <p>Use technology to build a table and graph the function <m>f</m> where <m>f(x)=\frac{1}{x^2}</m>. Find the function's domain and range.</p>
             </statement>
             <solution>
                 <p>With technology, we will choose the starting value of <m>-2</m> and an increment of <m>0.5</m>, and look at values in a table:</p>
@@ -817,7 +817,7 @@
                     <li>
                         <p>To make the average cost of producing each pair of shoes cheaper than <m>\$50.00</m>, at least how many pairs of shoes must the company produce?</p>
 
-                        <p>To answer this question, we locate the point where its <m>y</m>-value is <m>50</m>. With technology, we graph both the function <m>\bar{C}(x)</m> and <m>y=50</m>, and locate their intersection.</p>
+                        <p>To answer this question, we locate the point where its <m>y</m>-value is <m>50</m>. With technology, we graph both <m>y=\bar{C}(x)</m> and <m>y=50</m>, and locate their intersection.</p>
 
                         <figure>
                             <caption>Intersection of <m>\bar{C}(x)=\frac{30x+300000}{x}</m> and <m>y=50</m></caption>

--- a/src/section-properties-of-quadratic-functions.ptx
+++ b/src/section-properties-of-quadratic-functions.ptx
@@ -46,7 +46,7 @@
         <subsection>
         <title>Properties of Quadratic Functions</title>  
 
-            <p>A toy rocket was fired from the ground and then flew into the air at a speed of 64 feet per second. The path of the rocket can be modeled by the function <m>f(t)=-16t^2+64t</m>. To see the shape of the function we will make a table of values and plot the points. For the table we we will choose some values for <m>t</m> and then evaluate the fuction at each <m>t</m>-value:</p>
+            <p>A toy rocket was fired from the ground and then flew into the air at a speed of 64 feet per second. The path of the rocket can be modeled by the function <m>f</m> where <m>f(t)=-16t^2+64t</m>. To see the shape of the function we will make a table of values and plot the points. For the table we we will choose some values for <m>t</m> and then evaluate the fuction at each <m>t</m>-value:</p>
                 <sidebyside widths="47% 47%" margins="0%" valign="middle">
 				    <table xml:id="table-basic-quadratic-function">
                     <caption>Function values and points for <m>f(t)=-16t^2+64t</m></caption>
@@ -990,7 +990,7 @@
 
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=x^2+2</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=x^2+2</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1051,7 +1051,7 @@
 
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=x^2+1</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=x^2+1</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1111,7 +1111,7 @@
         </exercise>
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=x^2-5</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=x^2-5</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1171,7 +1171,7 @@
         </exercise>
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=x^2-3</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=x^2-3</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1233,7 +1233,7 @@
 
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=(x-2)^2</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=(x-2)^2</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1293,7 +1293,7 @@
         </exercise>
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=(x-4)^2</m>. Use <m>x</m>-values from <m>-1</m> to <m>8</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=(x-4)^2</m>. Use <m>x</m>-values from <m>-1</m> to <m>8</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1370,7 +1370,7 @@
         </exercise>
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=(x+3)^2</m>. Use <m>x</m>-values from <m>-5</m> to <m>1</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=(x+3)^2</m>. Use <m>x</m>-values from <m>-5</m> to <m>1</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">
@@ -1430,7 +1430,7 @@
         </exercise>
         <exercise>
             <statement>
-                <p>Create a table of ordered pairs and then graph the function <m>y=(x+2)^2</m>.</p>
+                <p>Create a table of ordered pairs and then graph the function given by <m>y=(x+2)^2</m>.</p>
             </statement>
             <solution>
             <sidebyside widths="47% 47%" margins="0%">

--- a/src/section-using-technology-to-explore-functions.ptx
+++ b/src/section-using-technology-to-explore-functions.ptx
@@ -328,7 +328,7 @@
         <!--https://www.desmos.com/calculator/3doxbb3l89-->
         <example>
             <sidebyside widths="47% 47%" margins="0%">
-                <p>If we use graphing technology to graph the function <m>g(x) = 0.0002x^2 + 0.00146x + 0.00266</m>, we may be mislead by the way values are rounded. Without technology, we know that this function is a quadratic function and therefore has at most two <m>x</m>-intercepts and has a vertex that will determine the minimum function value. However, using technology we could obtain a graph with the following key points:</p>
+                <p>If we use graphing technology to graph the function <m>g</m> where <m>g(x) = 0.0002x^2 + 0.00146x + 0.00266</m>, we may be mislead by the way values are rounded. Without technology, we know that this function is a quadratic function and therefore has at most two <m>x</m>-intercepts and has a vertex that will determine the minimum function value. However, using technology we could obtain a graph with the following key points:</p>
                 <figure xml:id="figure-graph-with-rounding-issue">
                     <caption>Misleading graph</caption>
                     <image>


### PR DESCRIPTION
Alex: I searched all files to find instances of "the function f(x)=..." (for consistency, particularly given how the notation is emphasized in the function basics section). The ones I didn't/couldn't fix were WeBWorK ones that looked like this:

the function <m>h(t)=<var name="$func"/></m>
where h(t) was also C(t), S(d), and f(x)