### PR TITLE
Fix possible division by zero bug in WeBWorK problem.

### DIFF
--- a/src/section-variables-and-evaluating-expressions.ptx
+++ b/src/section-variables-and-evaluating-expressions.ptx
@@ -1307,7 +1307,9 @@
               $var = RandomVariableName();
               Context()->variables->are($var=>'Real');
               $x = random(-9,9,1);
-              $h = random(-9,9,1);
+              do {
+                $h = random(-9,9,1);
+              } until ($x != $h);
               $k = random(-9,9,1);
               $denom = $x - $h;
               $expression = Formula("1/$denom($var - $h)^2 + $k")->reduce;

--- a/src/section-variables-and-evaluating-expressions.ptx
+++ b/src/section-variables-and-evaluating-expressions.ptx
@@ -1277,7 +1277,9 @@
               $var = RandomVariableName();
               Context()->variables->are($var=>'Real');
               $x = random(-9,9,1);
-              $h = random(-9,9,1);
+              do {
+                $h = random(-9,9,1);
+              } until ($x != $h);
               $k = random(-9,9,1);
               $denom = $x - $h;
               $expression = Formula("1/$denom($var - $h)^2 + $k")->reduce;


### PR DESCRIPTION
If $x and $h are randomly chosen to be the same number, then $denom will be
0, resulting in a division by zero error, which one of my students ran into.

This patch fixes this bug by using a do-until loop to keep picking $h until
it's different than $x.