### PR TITLE
Update section-combining-like-terms.ptx

### DIFF
--- a/src/section-combining-like-terms.ptx
+++ b/src/section-combining-like-terms.ptx
@@ -3494,5 +3494,103 @@
       </exercise>
     </sidebyside>
   </worksheet> -->
+  
+    <exercisegroup>
+        <introduction>
+            <p>Challenge Problems</p>
+        </introduction>
+
+            <exercise>
+                <webwork>
+                    <pg-macros>
+                        <macro-file>contextRationalFunction.pl</macro-file>
+                    </pg-macros>
+                    <setup>
+                        <pg-code>
+                            Context("RationalFunction-Strict");
+                            Context()->variables->are(a=>'Real');
+                            $p = random(1,9,1);
+                            $q = random(1,9,1);
+                            $num = $p+$q;
+                            $answer = Formula("$num/a");
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <!--Section 1.1-->
+                        <p>Given that <m>a\neq0</m>, simplify the following <m>\frac{<var name="$p"/>}{a} + \frac{<var name="$q"/>}{a}</m>.</p>
+                        <p><var name="$answer" width="10" /></p>
+                    </statement>
+                    <solution>
+                        <p>Since the fractions have the same denominator, we can just add numerators and keep that denominator the same.<md>
+                            <mrow>\frac{<var name="$p"/>}{a} + \frac{<var name="$q"/>}{a}   \amp =  \frac{<var name="$p"/>+<var name="$q"/>}{a}</mrow>
+                            <mrow>                                                          \amp = <var name="$answer" /></mrow>
+                        </md></p>
+                    </solution>
+                </webwork>
+            </exercise>
+
+            <exercise>
+                <webwork>
+                    <pg-macros>
+                        <macro-file>contextRationalFunction.pl</macro-file>
+                    </pg-macros>
+                    <setup>
+                        <pg-code>
+                            Context("RationalFunction-Strict");
+                            Context()->variables->are(a=>'Real');
+                            $p = random(1,9,1);
+                            $q = random(1,9,2);
+                            $num = (2*$p+$q);
+                            $answer = Formula("$num/(2a)");
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <!--Section 1.1-->
+                        <p>Given that <m>a\neq0</m>, simplify the following <m>\frac{<var name="$p"/>}{a} + \frac{<var name="$q"/>}{2a}</m>.</p>
+                        <p><var name="$answer" width="10" /></p>
+                    </statement>
+                    <solution>
+                        <p>Since the fractions don't have the same denominator, we have to make them have like denominators.  You should multiply the first fraction by <m>\frac{2}{2}</m>.
+                        <md>
+                            <mrow>\frac{<var name="$p"/>}{a} + \frac{<var name="$q"/>}{2a}    \amp = \frac{2 \cdot<var name="$p"/>}{2a} + \frac{<var name="$q"/>}{2a} </mrow>
+                            <mrow>                                                            \amp =  \frac{2 \cdot <var name="$p"/>+<var name="$q"/>}{2a}</mrow>
+                            <mrow>                                                            \amp = <var name="$answer" /></mrow>
+                        </md></p>
+                    </solution>
+                </webwork>
+            </exercise>
+
+            <exercise>
+                <webwork>
+                    <pg-macros>
+                        <macro-file>contextRationalFunction.pl</macro-file>
+                    </pg-macros>
+                    <setup>
+                        <pg-code>
+                            Context("RationalFunction-Strict");
+                            Context()->variables->are(a=>'Real');
+                            $p = random(1,9,1);
+                            do {$q = random(1,9,1);} until ($q % 5 != 0);
+                            $num = (5*$p-$q);
+                            $answer = Formula("$num/(5a)");
+                        </pg-code>
+                    </setup>
+                    <statement>
+                        <!--Section 1.1-->
+                        <p>Given that <m>a\neq0</m>, simplify the following: <m>\frac{<var name="$p"/>}{a} - \frac{<var name="$q"/>}{5a}</m>.</p>
+                        <p><var name="$answer" width="10" /></p>
+                    </statement>
+                    <solution>
+                        <p>Since the fractions don't have the same denominator, we have to make them have like denominators.  You should multiply the first fraction by <m>\frac{5}{5}</m>.
+                        <md>
+                            <mrow>\frac{<var name="$p"/>}{a} + \frac{<var name="$q"/>}{2a}    \amp = \frac{5 \cdot<var name="$p"/>}{5a} - \frac{<var name="$q"/>}{5a}</mrow>
+                            <mrow>                                                            \amp = \frac{5 \cdot<var name="$p"/> - <var name="$q"/>}{5a}</mrow>
+                            <mrow>                                                            \amp = <var name="$answer" /></mrow>
+                        </md></p>
+                    </solution>
+                </webwork>
+            </exercise>
+      
+      </exercisegroup>
 </section>
 


### PR DESCRIPTION
I added in 3 challenge problems from ORCCA edition 1.  They were in ORCCA edition 1, section 1.2 on fractions.  They aren't anywhere in ORCCA edition 2.  I thought they fit best in "Combining Like terms."