### PR TITLE
Added non-WW non-multiple choice exercises, line 26

### DIFF
--- a/src/section-function-basics.ptx
+++ b/src/section-function-basics.ptx
@@ -2248,6 +2248,62 @@
     </exercisegroup>
     <exercisegroup permid="ACd">
       <title>Functions in Context</title>
+
+      <exercise>
+        <statement>
+          <p>
+            You have a savings account at a bank which accrues some interest over time.
+            The function <m>M(t)=0.75t+100</m> models the amount of money, in dollars, in the savings account <m>t</m> months after it was initially setup.
+          </p>
+          <p>
+            Interpret the meaning of <m>M(20)=115</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Note that <m>M(t)</m> tells us the amount of money, in dollars, in the account <m>t</m> months after the account was initially setup.
+            Then <m>M(20)=115</m> must tell us that after <m>20</m> months, the account will have <m>115</m> dollars.
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A seafood company exports from Portland, Oregon to local restaurants in the city.
+            They want to begin exporting outside of Portland.
+            The formula <m>C(m)=\frac{1}{5}\sqrt{25m}</m> models the cost, in dollars, to export seafood <m>m</m> miles away from Portland.
+          </p>
+          <p>
+            Interpret the meaning of <m>C(144)=12</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Note that <m>C(m)</m> tells us the cost, in dollars, to export seafood <m>m</m> miles away from Portland.
+            Then <m>C(144)=12</m> must tell us that the cost to export seafood <m>144</m> miles from Portland is <m>12</m> dollars.
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A group of scientists are studying the relationship between the salinity (salt concentration) and the oxygen concentration in the Columbia River Estuary.
+            The formula <m>G(x)=-\frac{1}{100}x^2+100</m> models the oxygen concentration, as a percentage, when the salinity in the estuary is at <m>x</m> percent.
+          </p>
+          <p>
+            Interpret the meaning of <m>G(35)=87.75</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Note that <m>G(x)</m> tells us the oxygen concentration, as a percentage, when the salinity is at <m>x</m> percent.
+            Then <m>G(35)=87.75</m> tells us that the oxygen concentration is <m>87.75\%</m> when the salinity is <m>35\%</m>.
+          </p>
+        </answer>
+      </exercise>
+
       <exercise permid="pma">
         <webwork source="Contrib/PCC/BasicAlgebra/FunctionBasics/FunctionInContext10.pg" />
       </exercise>

--- a/src/section-function-basics.ptx
+++ b/src/section-function-basics.ptx
@@ -2253,7 +2253,7 @@
         <statement>
           <p>
             You have a savings account at a bank which accrues some interest over time.
-            The function <m>M(t)=0.75t+100</m> models the amount of money, in dollars, in the savings account <m>t</m> months after it was initially setup.
+            The formula <m>M(t)=0.75t+100</m> models the amount of money, in dollars, in the savings account <m>t</m> months after it was initially setup.
           </p>
           <p>
             Interpret the meaning of <m>M(20)=115</m>.
@@ -2262,7 +2262,7 @@
         <answer>
           <p>
             Note that <m>M(t)</m> tells us the amount of money, in dollars, in the account <m>t</m> months after the account was initially setup.
-            Then <m>M(20)=115</m> must tell us that after <m>20</m> months, the account will have <m>115</m> dollars.
+            Thus <m>M(20)=115</m> must tell us that after <m>20</m> months, the account will have <m>115</m> dollars.
           </p>
         </answer>
       </exercise>
@@ -2272,16 +2272,16 @@
           <p>
             A seafood company exports from Portland, Oregon to local restaurants in the city.
             They want to begin exporting outside of Portland.
-            The formula <m>C(m)=\frac{1}{5}\sqrt{25m}</m> models the cost, in dollars, to export seafood <m>m</m> miles away from Portland.
+            The formula <m>C(m)=\frac{1}{2}\sqrt{m}</m> models the cost, in dollars, to export seafood <m>m</m> miles away from Portland.
           </p>
           <p>
-            Interpret the meaning of <m>C(144)=12</m>.
+            Interpret the meaning of <m>C(144)=6</m>.
           </p>
         </statement>
         <answer>
           <p>
             Note that <m>C(m)</m> tells us the cost, in dollars, to export seafood <m>m</m> miles away from Portland.
-            Then <m>C(144)=12</m> must tell us that the cost to export seafood <m>144</m> miles from Portland is <m>12</m> dollars.
+            Thus <m>C(144)=6</m> must tell us that the cost to export seafood <m>144</m> miles from Portland is <m>6</m> dollars.
           </p>
         </answer>
       </exercise>
@@ -2299,7 +2299,25 @@
         <answer>
           <p>
             Note that <m>G(x)</m> tells us the oxygen concentration, as a percentage, when the salinity is at <m>x</m> percent.
-            Then <m>G(35)=87.75</m> tells us that the oxygen concentration is <m>87.75\%</m> when the salinity is <m>35\%</m>.
+            Thus <m>G(35)=87.75</m> must tell us that the oxygen concentration is <m>87.75\%</m> when the salinity is <m>35\%</m>.
+          </p>
+        </answer>
+      </exercise>
+
+      <exercise>
+        <statement>
+          <p>
+            A group of engineers are studying the effects of temperature on the lifetime of a specific type of battery.
+            The formula <m>L(T)=-0.45T+21</m> models the lifetime, in years, of the battery if it is kept in an environment with a temperature of <m>T</m> degrees Celsius.
+          </p>
+          <p>
+            Interpret the meaning of <m>L(27)=8.85</m>.
+          </p>
+        </statement>
+        <answer>
+          <p>
+            Note that <m>L(T)</m> tells us the lifetime, in years, of the battery when it is kept in an environment at <m>T</m> degrees Celcius.
+            Thus <m>L(27)=8.85</m> must tell us that the battery's lifetime is <m>8.85</m> years when it is kept at a temperature of <m>27</m> degrees Celsius.
           </p>
         </answer>
       </exercise>


### PR DESCRIPTION
The exercises currently on ORCCA in section 11.1 starting at 81 all use linear functions. I'm not sure if you wanted to have other types of functions on here like quadratic or with radicals, however since they do appear before 11.1 I assume it was okay to use for the sake of problem variety.

Let me know if I should rewrite these with linear functions if there are plans to reorder this section before quadratics or radicals.